### PR TITLE
FE - Three dot selector - change order: Send, Preview in channel, Edit, Duplicate, separator, Delete; (separator: hex #F3F2F1, 100% opacity (2px line, 4px above and below)); looks like tooltip (Pointer arrow at the top of the dropdown selector) - overall, can we remove that to align with what is in Teams?

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/DraftMessages/draftMessages.scss
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/DraftMessages/draftMessages.scss
@@ -75,3 +75,9 @@
     }
   }
 }
+
+.divider {
+  height: 0.2rem;
+  background-color: #F3F2F1;
+  margin: 0.4rem 0rem;
+}

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/DraftMessages/draftMessages.tsx
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/DraftMessages/draftMessages.tsx
@@ -11,7 +11,7 @@ import { selectMessage, getDraftMessagesList, getMessagesList } from '../../acti
 import { getBaseUrl } from '../../configVariables';
 import * as microsoftTeams from "@microsoft/teams-js";
 import { Loader } from '@stardust-ui/react';
-import { IButtonProps, CommandBar, DirectionalHint } from 'office-ui-fabric-react';
+import { IButtonProps, CommandBar, DirectionalHint, DropdownMenuItemType } from 'office-ui-fabric-react';
 import { deleteDraftNotification, duplicateDraftNotification } from '../../apis/messageListApi';
 
 export interface ITaskInfo {
@@ -121,9 +121,9 @@ class DraftMessages extends React.Component<IMessageProps, IMessageState> {
                 ariaLabel: 'More commands',
                 menuProps: {
                   items: [], // Items must be passed for typesafety, but commandBar will determine items rendered in overflow
-                  isBeakVisible: true,
+                  isBeakVisible: false,
                   beakWidth: 20,
-                  gapSpace: 10,
+                  gapSpace: 5,
                   directionalHint: DirectionalHint.bottomCenter
                 },
                 className: 'moreBtn'
@@ -219,6 +219,14 @@ class DraftMessages extends React.Component<IMessageProps, IMessageState> {
     let id = item.id;
     return [
       {
+        key: 'send',
+        name: 'Send',
+        onClick: () => {
+          let url = getBaseUrl() + "/sendconfirmation/" + id;
+          this.onOpenTaskModule(null, url, "Send confirmation");
+        },
+      },
+      {
         key: 'preview',
         name: 'Preview in this channel',
         onClick: () => {
@@ -234,15 +242,6 @@ class DraftMessages extends React.Component<IMessageProps, IMessageState> {
         }
       },
       {
-        key: 'delete',
-        name: 'Delete',
-        onClick: () => {
-          this.deleteDraftMessage(id).then(() => {
-            this.props.getDraftMessagesList();
-          });
-        }
-      },
-      {
         key: 'duplicate',
         name: 'Duplicate',
         onClick: () => {
@@ -252,13 +251,18 @@ class DraftMessages extends React.Component<IMessageProps, IMessageState> {
         },
       },
       {
-        key: 'send',
-        name: 'Send',
+        key: 'divider',
+        className: "divider",
+      },
+      {
+        key: 'delete',
+        name: 'Delete',
         onClick: () => {
-          let url = getBaseUrl() + "/sendconfirmation/" + id;
-          this.onOpenTaskModule(null, url, "Send confirmation");
-        },
-      }
+          this.deleteDraftMessage(id).then(() => {
+            this.props.getDraftMessagesList();
+          });
+        }
+      },
     ];
   };
 

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/Messages/messages.tsx
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/Messages/messages.tsx
@@ -176,9 +176,9 @@ class Messages extends React.Component<IMessageProps, IMessageState> {
                 ariaLabel: 'More commands',
                 menuProps: {
                   items: [], // Items must be passed for typesafety, but commandBar will determine items rendered in overflow
-                  isBeakVisible: true,
+                  isBeakVisible: false,
                   beakWidth: 20,
-                  gapSpace: 10,
+                  gapSpace: 5,
                   directionalHint: DirectionalHint.bottomCenter
                 },
                 className: 'moreBtn'


### PR DESCRIPTION
FE - Three dot selector - change order: Send, Preview in channel, Edit, Duplicate, separator, Delete; (separator: hex #F3F2F1, 100% opacity (2px line, 4px above and below)); looks like tooltip (Pointer arrow at the top of the dropdown selector) - overall, can we remove that to align with what is in Teams?