### PR TITLE
Add workaround to treat user remove from tenant when processing notifications.

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -111,7 +111,7 @@
       "metadata": {
         "description": "The URL to the GitHub repository to deploy."
       },
-      "defaultValue": "https://github.com/OfficeDev/microsoft-teams-company-communicator-app.git"
+      "defaultValue": "https://github.com/sergiorru/microsoft-teams-company-communicator-app.git"
     },
     "gitBranch": {
       "type": "string",

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/package-lock.json
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ui-sample",
-  "version": "0.1.0",
+  "name": "company-communicator",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/config.tsx
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/src/components/config.tsx
@@ -21,7 +21,7 @@ class Configuration extends React.Component<{}, IConfigState> {
             microsoftTeams.settings.setSettings({
                 entityId: "Company_Communicator_App",
                 contentUrl: this.state.url,
-                suggestedDisplayName: "Company Communicator",
+                suggestedDisplayName: "Communicator Broadcaster Tab",
             });
             saveEvent.notifySuccess();
         });


### PR DESCRIPTION
In this pull request, I added an workaround to treat user remove from tenant when processing notifications. 

Some cases when a user is removed from tenant, an reference (ChannelAccount) remain in Conversation, and when bot retrieves conversation members an object is returned without objectId (consequently user AadID). When it happens an generic error is reported to the notification sender in the app.