### PR TITLE
Avoid sending empty batch requests to Graph

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Microsoft.Teams.Apps.CompanyCommunicator.Common.csproj
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Microsoft.Teams.Apps.CompanyCommunicator.Common.csproj
@@ -12,7 +12,11 @@
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Microsoft.Teams.App.CompanyCommunicator.Common.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="1.0.6" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.1" />

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/Export/Extensions/UserExtensions.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/Export/Extensions/UserExtensions.cs
@@ -34,7 +34,10 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Extensions
                 }
             }
 
-            yield return buffer;
+            if (buffer.Count > 0)
+            {
+                yield return buffer;
+            }
         }
     }
 }

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.sln
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Teams.Apps.Compan
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Teams.Apps.CompanyCommunicator.Send.Func.Test", "Test\Microsoft.Teams.Apps.CompanyCommunicator.Send.Func.Test\Microsoft.Teams.Apps.CompanyCommunicator.Send.Func.Test.csproj", "{7426FDC6-72E9-41BA-8686-A881F1DCBAAC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Teams.App.CompanyCommunicator.Common.Test", "Test\Microsoft.Teams.App.CompanyCommunicator.Common.Test\Microsoft.Teams.App.CompanyCommunicator.Common.Test.csproj", "{B30048CC-3631-49F1-AF01-6A58F645C6EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{7426FDC6-72E9-41BA-8686-A881F1DCBAAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7426FDC6-72E9-41BA-8686-A881F1DCBAAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7426FDC6-72E9-41BA-8686-A881F1DCBAAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B30048CC-3631-49F1-AF01-6A58F645C6EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B30048CC-3631-49F1-AF01-6A58F645C6EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B30048CC-3631-49F1-AF01-6A58F645C6EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B30048CC-3631-49F1-AF01-6A58F645C6EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,6 +78,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{B28BD9B9-BBB0-43E3-8BD1-9F4A0B9841C3} = {351E3064-5E5C-4AC4-AB1F-D4FDFF162749}
 		{7426FDC6-72E9-41BA-8686-A881F1DCBAAC} = {351E3064-5E5C-4AC4-AB1F-D4FDFF162749}
+		{B30048CC-3631-49F1-AF01-6A58F645C6EB} = {351E3064-5E5C-4AC4-AB1F-D4FDFF162749}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {082E8AB4-A506-4AFC-B113-A87C1C31EA00}

--- a/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test.csproj
+++ b/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.Graph" Version="3.22.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Teams.Apps.CompanyCommunicator.Common\Microsoft.Teams.Apps.CompanyCommunicator.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/MicrosoftGraph/UsersServiceTests.cs
+++ b/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/MicrosoftGraph/UsersServiceTests.cs
@@ -1,0 +1,217 @@
+﻿// <copyright file="UsersServiceTests.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.App.CompanyCommunicator.Common.Test.Services.MicrosoftGraph
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Graph;
+    using Microsoft.Teams.App.CompanyCommunicator.Common.Test.Services.Mock;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Users Service unit tests.
+    /// </summary>
+    public class UsersServiceTests
+    {
+        /// <summary>
+        /// Test case to check if Users service is instanticated successfully.
+        /// </summary>
+        [Fact]
+        public void CreateInstance_AllParameters_ShouldBeSuccess()
+        {
+            // Arrange
+            Mock<IGraphServiceClient> graphServiceClientMock = new Mock<IGraphServiceClient>();
+            Action action = () => new UsersService(graphServiceClientMock.Object);
+
+            // Act and Assert.
+            action.Should().NotThrow();
+        }
+
+        /// <summary>
+        /// Test case to check if ArgumentNullException is thrown for null parameters.
+        /// </summary>
+        [Fact]
+        public void CreateInstance_NullParameters_ThrowsArgumentNullException()
+        {
+            // Arrange
+            Action action = () => new UsersService(null);
+
+            // Act and Assert.
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        /// <summary>
+        /// Test case to check if ArgumentNullException is thrown for null parameter in GetBatchByUserIds method.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_NullParameter_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var usersServiceInstance = this.GetUsersService();
+
+            // Act
+            Func<Task> task = async () => await usersServiceInstance.GetBatchByUserIds(null);
+
+            // Assert
+            await task.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        /// <summary>
+        /// Test case to check if response is empty for empty parameters.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_EmptyParameter_ReturnsEmptyResponse()
+        {
+            // Arrange
+            var usersServiceInstance = this.GetUsersService();
+            var usersByGroups = new List<List<string>>();
+
+            // Act
+            var users = await usersServiceInstance.GetBatchByUserIds(usersByGroups);
+
+            // Assert
+            Assert.Empty(users);
+        }
+
+        /// <summary>
+        /// Test case to check if InvalidOperationException is thrown if user batch count is over 15.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_UserBatchCountOver15_ShouldThrowInvalidOperationExcetpion()
+        {
+            // Arrange
+            var usersService = this.GetUsersService();
+            var usersByGroups = new List<List<string>>
+            {
+                new List<string>()
+                { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17" },
+            };
+
+            // Act
+            Func<Task> task = async () => await usersService.GetBatchByUserIds(usersByGroups);
+
+            // Assert
+            await task.Should().ThrowAsync<InvalidOperationException>();
+        }
+
+        /// <summary>
+        /// Test case to check if we get exact batch count of 8.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_UserBatchSizeOver20_ShouldMatchResponseCount()
+        {
+            // Arrange
+            var usersService = this.GetUsersService();
+            var userIdBatch = new List<string>() { "1" };
+
+            // Adding 21 batches.
+            var usersByGroups = new List<List<string>>() { userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch, userIdBatch };
+
+            // Act
+            var users = await usersService.GetBatchByUserIds(usersByGroups);
+
+            // Assert
+            // 1 Batch should have 4 user count, expected is 2 batch hence 8.
+            Assert.Equal(8, users.Count());
+        }
+
+        /// <summary>
+        /// Test case to check if we user mapping is correct.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_AllParameters_ShouldMapCorrectly()
+        {
+            // Arrange
+            var usersService = this.GetUsersService();
+            var users = new List<string>() { "1" };
+            var usersByGroups = new List<List<string>>() { users };
+
+            // Act
+            var resp = await usersService.GetBatchByUserIds(usersByGroups);
+
+            // Assert
+            Assert.Equal("test-id-1", resp.FirstOrDefault().Id);
+            Assert.Equal("test-display-id-1", resp.FirstOrDefault().DisplayName);
+        }
+
+        /// <summary>
+        /// Test case to check if we get exact batch count of 4.
+        /// </summary>
+        [Fact]
+        public async void GetBatch_UserBatchSizeOf1_ShouldMatchResponseCount()
+        {
+            // Arrange
+            var usersService = this.GetUsersService();
+            var users = new List<string>() { "1" };
+            var usersByGroups = new List<List<string>>() { users };
+
+            // Act
+            var resp = await usersService.GetBatchByUserIds(usersByGroups);
+
+            // Assert
+            Assert.Equal(4, resp.Count());
+        }
+
+        private UsersService GetUsersService()
+        {
+            MockHttpProvider mockHttpProvider = new MockHttpProvider();
+            mockHttpProvider.Responses.Add("POST:https://graph.microsoft.com/v1.0/$batch", new
+            {
+                responses = new List<object>()
+                {
+                    new
+                    {
+                        id = "1",
+                        body = new
+                        {
+                          value = new List<User>()
+                          {
+                            new User()
+                            {
+                                DisplayName = "test-display-id-1",
+                                Id = "test-id-1",
+                            },
+                            new User()
+                            {
+                                DisplayName = "test-display-id-2",
+                                Id = "test-id-2",
+                            },
+                          },
+                        },
+                    },
+                    new
+                    {
+                        id = "2",
+                        body = new
+                        {
+                          value = new List<User>()
+                          {
+                            new User()
+                            {
+                                DisplayName = "test-display-id-3",
+                                Id = "test-id-3",
+                            },
+                            new User()
+                            {
+                                DisplayName = "test-display-id-4",
+                                Id = "test-id-4",
+                            },
+                          },
+                        },
+                    },
+                },
+            });
+
+            GraphServiceClient client = new GraphServiceClient(new MockAuthenticationHelper(), mockHttpProvider);
+            return new UsersService(client);
+        }
+    }
+}

--- a/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/Mock/MockAuthenticationHelper.cs
+++ b/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/Mock/MockAuthenticationHelper.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="MockAuthenticationHelper.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.App.CompanyCommunicator.Common.Test.Services.Mock
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Graph;
+
+    /// <summary>
+    /// Mocking Authentication Provider.
+    /// </summary>
+    public class MockAuthenticationHelper : IAuthenticationProvider
+    {
+        /// <summary>
+        /// Mock authenticate request.
+        /// </summary>
+        /// <param name="request">Represents a HttpRequestMessage.</param>
+        /// <returns>asynchronous operation.</returns>
+        public Task AuthenticateRequestAsync(HttpRequestMessage request)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/Mock/MockHttpProvider.cs
+++ b/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/Services/Mock/MockHttpProvider.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="MockHttpProvider.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.App.CompanyCommunicator.Common.Test.Services.Mock
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Graph;
+
+    /// <summary>
+    /// Mocking Http provider.
+    /// </summary>
+    public class MockHttpProvider : IHttpProvider
+    {
+        /// <inheritdoc/>
+        public ISerializer Serializer { get; } = new Serializer();
+
+        /// <inheritdoc/>
+        public TimeSpan OverallTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Gets or sets response mapping with key, resposne.
+        /// </summary>
+        public Dictionary<string, object> Responses { get; set; } = new Dictionary<string, object>();
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc/>
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            string key = request.Method.ToString() + ":" + request.RequestUri.ToString();
+            var response = new HttpResponseMessage();
+            if (this.Responses.ContainsKey(key) && response.Content == null)
+            {
+                response.Content = new StringContent(this.Serializer.SerializeObject(this.Responses[key]));
+            }
+
+            return Task.FromResult(response);
+        }
+
+        /// <inheritdoc/>
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        {
+            return this.SendAsync(request);
+        }
+    }
+}

--- a/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/stylecop.json
+++ b/Source/Test/Microsoft.Teams.App.CompanyCommunicator.Common.Test/stylecop.json
@@ -1,0 +1,15 @@
+﻿{
+  // ACTION REQUIRED: This file was automatically added to your project, but it
+  // will not take effect until additional steps are taken to enable it. See the
+  // following page for additional information:
+  //
+  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Microsoft",
+      "copyrightText": "Copyright (c) {companyName} Corporation.\nLicensed under the MIT License."
+    }
+  }
+}


### PR DESCRIPTION
For certain counts of users, the current logic for batching Graph requests results in a trailing batch with 0 requests. Graph rejects these with 400 Bad Request, causing errors when exporting send results.
This PR includes the fix for export and unit test cases.