### PR TITLE
change notification only to "false"

### DIFF
--- a/Manifest/manifest_users.json
+++ b/Manifest/manifest_users.json
@@ -30,7 +30,7 @@
       "team"
     ],
     "supportsFiles": false,
-    "isNotificationOnly": true
+    "isNotificationOnly": false
   }],
   "permissions": [
     "identity",


### PR DESCRIPTION
This bot is not "chat-style" conversational interactive, but it is incorrect to set notification only to "true" since that suppresses notifications and alerts. This bot is used to communicate important news and information to users, and customers have stopped deploying it because the alerts are blocked. Also, the design of the card encourages interactivity (buttons, card updates, etc.) so why it is not strictly conversation, it is "interactive" and certainly the messages are important. 

This setting should be changed to "false", and the docs should be updated to call out that if someone wants to suppress notifications, they can always set it back to "true".