### PR TITLE
Bump react-scripts from 3.4.1 to 4.0.3 in /Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp #356

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/package.json
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp/package.json
@@ -25,7 +25,7 @@
     "react-highlight-words": "^0.16.0",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.0",
-    "react-scripts": "^3.4.1",
+    "react-scripts": "^4.0.3",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "typescript": "3.5.1",


### PR DESCRIPTION
Bump react-scripts from 3.4.1 to 4.0.3 in /Source/Microsoft.Teams.Apps.CompanyCommunicator/ClientApp #356

To handle HIGH VA, during downloading react-scripts package and it's dependencies, bump react-scripts package version from 3.4.1 to 4.0.3