### PR TITLE
Scale for large audience.

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Repositories/BaseRepository.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Repositories/BaseRepository.cs
@@ -192,6 +192,37 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories
         }
 
         /// <summary>
+        /// Get paged data entities from the table storage in a partition.
+        /// </summary>
+        /// <param name="partition">Partition key value.</param>
+        /// <param name="count">The max number of desired entities.</param>
+        /// <returns>All data entities and continuation token.</returns>
+        public async Task<(IEnumerable<T>, TableContinuationToken)> GetByCountAsync(string partition = null, int? count = null)
+        {
+            var partitionKeyFilter = this.GetPartitionKeyFilter(partition);
+            var query = new TableQuery<T>().Where(partitionKeyFilter);
+            query.TakeCount = count;
+            TableQuerySegment<T> seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, null);
+            return (seg.Results, seg.ContinuationToken);
+        }
+
+        /// <summary>
+        /// Get data entities from the table storage in a partition using token.
+        /// </summary>
+        /// <param name="token">Continuation token.</param>
+        /// <param name="partition">Partition key value.</param>
+        /// <param name="count">The max number of desired entities.</param>
+        /// <returns>All data entities.</returns>
+        public async Task<(IEnumerable<T>, TableContinuationToken)> GetByTokenAsync(TableContinuationToken token, string partition = null, int? count = null)
+        {
+            var partitionKeyFilter = this.GetPartitionKeyFilter(partition);
+            var query = new TableQuery<T>().Where(partitionKeyFilter);
+            query.TakeCount = count;
+            TableQuerySegment<T> seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, token);
+            return (seg.Results, seg.ContinuationToken);
+        }
+
+        /// <summary>
         /// Get filtered data entities by date time from the table storage.
         /// </summary>
         /// <param name="dateTime">less than date time.</param>

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Repositories/BaseRepository.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Repositories/BaseRepository.cs
@@ -196,29 +196,21 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories
         /// </summary>
         /// <param name="partition">Partition key value.</param>
         /// <param name="count">The max number of desired entities.</param>
+        /// <param name="token">The continuation token.</param>
         /// <returns>All data entities and continuation token.</returns>
-        public async Task<(IEnumerable<T>, TableContinuationToken)> GetByCountAsync(string partition = null, int? count = null)
+        public async Task<(IEnumerable<T>, TableContinuationToken)> GetPagedAsync(string partition = null, int? count = null, TableContinuationToken token = null)
         {
             var partitionKeyFilter = this.GetPartitionKeyFilter(partition);
             var query = new TableQuery<T>().Where(partitionKeyFilter);
             query.TakeCount = count;
-            TableQuerySegment<T> seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, null);
-            return (seg.Results, seg.ContinuationToken);
-        }
+            TableQuerySegment<T> seg;
+            if (token == null)
+            {
+                seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, null);
+                return (seg.Results, seg.ContinuationToken);
+            }
 
-        /// <summary>
-        /// Get data entities from the table storage in a partition using token.
-        /// </summary>
-        /// <param name="token">Continuation token.</param>
-        /// <param name="partition">Partition key value.</param>
-        /// <param name="count">The max number of desired entities.</param>
-        /// <returns>All data entities.</returns>
-        public async Task<(IEnumerable<T>, TableContinuationToken)> GetByTokenAsync(TableContinuationToken token, string partition = null, int? count = null)
-        {
-            var partitionKeyFilter = this.GetPartitionKeyFilter(partition);
-            var query = new TableQuery<T>().Where(partitionKeyFilter);
-            query.TakeCount = count;
-            TableQuerySegment<T> seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, token);
+            seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, token);
             return (seg.Results, seg.ContinuationToken);
         }
 

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/PreparingToSend/Activities/GetRecipientsActivity.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/PreparingToSend/Activities/GetRecipientsActivity.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.NotificationData;
@@ -19,6 +20,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     public class GetRecipientsActivity
     {
         private readonly SentNotificationDataRepository sentNotificationDataRepository;
+        private readonly int maxResultSize = 100000;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetRecipientsActivity"/> class.
@@ -35,10 +37,60 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// <param name="notification">notification.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [FunctionName(FunctionNames.GetRecipientsActivity)]
-        public async Task<IEnumerable<SentNotificationDataEntity>> GetRecipientsAsync([ActivityTrigger] NotificationDataEntity notification)
+        public async Task<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)> GetRecipientsAsync([ActivityTrigger] NotificationDataEntity notification)
         {
-            var recipients = await this.sentNotificationDataRepository.GetAllAsync(notification.Id);
-            return recipients;
+            if (notification == null)
+            {
+                throw new ArgumentNullException(nameof(notification));
+            }
+
+            var results = await this.sentNotificationDataRepository.GetByCountAsync(notification.Id, 1000);
+            var recipients = new List<SentNotificationDataEntity>();
+            recipients.AddRange(results.Item1);
+            while (results.Item2 != null && recipients.Count < this.maxResultSize)
+            {
+                results = await this.sentNotificationDataRepository.GetByTokenAsync(results.Item2, notification.Id);
+                if (results.Item1 != null && results.Item1.Count() > 0)
+                {
+                    recipients.AddRange(results.Item1);
+                }
+            }
+
+            return (recipients, results.Item2);
+        }
+
+        /// <summary>
+        /// Reads all the recipients from Sent notification table.
+        /// </summary>
+        /// <param name="input">Input containing notification id and continuation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [FunctionName(FunctionNames.GetRecipientsByTokenActivity)]
+        public async Task<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)> GetRecipientsByTokenAsync(
+            [ActivityTrigger](string notificationId, TableContinuationToken tableContinuationToken) input)
+        {
+            if (input.notificationId == null)
+            {
+                throw new ArgumentNullException(nameof(input.notificationId));
+            }
+
+            if (input.tableContinuationToken == null)
+            {
+                throw new ArgumentNullException(nameof(input.tableContinuationToken));
+            }
+
+            var recipients = new List<SentNotificationDataEntity>();
+            while (input.tableContinuationToken != null && recipients.Count < this.maxResultSize)
+            {
+                var results = await this.sentNotificationDataRepository.GetByTokenAsync(input.tableContinuationToken, input.notificationId);
+                if (results.Item1 != null && results.Item1.Count() > 0)
+                {
+                    recipients.AddRange(results.Item1);
+                }
+
+                input.tableContinuationToken = results.Item2;
+            }
+
+            return (recipients, input.tableContinuationToken);
         }
 
         /// <summary>

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/PreparingToSend/FunctionNames.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func/PreparingToSend/FunctionNames.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         public const string GetRecipientsActivity = nameof(GetRecipientsActivity);
 
         /// <summary>
+        /// Get recipients acitvity by token function.
+        /// </summary>
+        public const string GetRecipientsByTokenActivity = nameof(GetRecipientsByTokenActivity);
+
+        /// <summary>
         /// Get pending recipients (ie recipients with no conversation id in the database) acitvity function.
         /// </summary>
         public const string GetPendingRecipientsActivity = nameof(GetPendingRecipientsActivity);


### PR DESCRIPTION
The GetRecipientsActivity is changed to handle paged db data and will return token if more data is available. 
The activity response is capped at 100000 users. This will ensure we don't run into serialization issues and can handle large audiences. 