### PR TITLE
Scale for Large audience and theme fixes.

### DIFF
--- a/Source/CompanyCommunicator.Common/Repositories/BaseRepository.cs
+++ b/Source/CompanyCommunicator.Common/Repositories/BaseRepository.cs
@@ -164,6 +164,23 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories
         }
 
         /// <inheritdoc/>
+        public async Task<(IEnumerable<T>, TableContinuationToken)> GetPagedAsync(string partition = null, int? count = null, TableContinuationToken token = null)
+        {
+            var partitionKeyFilter = this.GetPartitionKeyFilter(partition);
+            var query = new TableQuery<T>().Where(partitionKeyFilter);
+            query.TakeCount = count;
+            TableQuerySegment<T> seg;
+            if (token == null)
+            {
+                seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, null);
+                return (seg.Results, seg.ContinuationToken);
+            }
+
+            seg = await this.Table.ExecuteQuerySegmentedAsync<T>(query, token);
+            return (seg.Results, seg.ContinuationToken);
+        }
+
+        /// <inheritdoc/>
         public async Task<IEnumerable<T>> GetAllLessThanDateTimeAsync(DateTime dateTime)
         {
             var filterByDate = TableQuery.GenerateFilterConditionForDate("Timestamp", QueryComparisons.LessThanOrEqual, dateTime);

--- a/Source/CompanyCommunicator.Common/Repositories/IRepository.cs
+++ b/Source/CompanyCommunicator.Common/Repositories/IRepository.cs
@@ -68,6 +68,15 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories
         public Task<IEnumerable<T>> GetAllAsync(string partition = null, int? count = null);
 
         /// <summary>
+        /// Get paged data entities from the table storage in a partition.
+        /// </summary>
+        /// <param name="partition">Partition key value.</param>
+        /// <param name="count">The max number of desired entities.</param>
+        /// <param name="token">The continuation token.</param>
+        /// <returns>All data entities and continuation token.</returns>
+        Task<(IEnumerable<T>, TableContinuationToken)> GetPagedAsync(string partition = null, int? count = null, TableContinuationToken token = null);
+
+        /// <summary>
         /// Get filtered data entities by date time from the table storage.
         /// </summary>
         /// <param name="dateTime">less than date time.</param>

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/GetRecipientsActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/GetRecipientsActivity.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.NotificationData;
@@ -19,6 +20,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     /// </summary>
     public class GetRecipientsActivity
     {
+        // Recommended data count size that should be returned from activity function to orchestrator.
+        // Please note that increasing this value can cause OutOfMemoryException.
+        private const int MaxResultSize = 100000;
+
+        // Maximum record count that Table storage returns.
+        private const int UserCount = 1000;
         private readonly ISentNotificationDataRepository sentNotificationDataRepository;
 
         /// <summary>
@@ -36,15 +43,64 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// <param name="notification">notification.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [FunctionName(FunctionNames.GetRecipientsActivity)]
-        public async Task<IEnumerable<SentNotificationDataEntity>> GetRecipientsAsync([ActivityTrigger] NotificationDataEntity notification)
+        public async Task<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)> GetRecipientsAsync([ActivityTrigger] NotificationDataEntity notification)
         {
             if (notification == null)
             {
                 throw new ArgumentNullException(nameof(notification));
             }
 
-            var recipients = await this.sentNotificationDataRepository.GetAllAsync(notification.Id);
-            return recipients;
+            var results = await this.sentNotificationDataRepository.GetPagedAsync(notification.Id, UserCount);
+            var recipients = new List<SentNotificationDataEntity>();
+            if (results.Item1 != null)
+            {
+                recipients.AddRange(results.Item1);
+            }
+
+            while (results.Item2 != null && recipients.Count < MaxResultSize)
+            {
+                results = await this.sentNotificationDataRepository.GetPagedAsync(notification.Id, UserCount, results.Item2);
+                if (results.Item1 != null)
+                {
+                    recipients.AddRange(results.Item1);
+                }
+            }
+
+            return (recipients, results.Item2);
+        }
+
+        /// <summary>
+        /// Reads all the recipients from Sent notification table.
+        /// </summary>
+        /// <param name="input">Input containing notification id and continuation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [FunctionName(FunctionNames.GetRecipientsByTokenActivity)]
+        public async Task<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)> GetRecipientsByTokenAsync(
+            [ActivityTrigger](string notificationId, TableContinuationToken tableContinuationToken) input)
+        {
+            if (input.notificationId == null)
+            {
+                throw new ArgumentNullException(nameof(input.notificationId));
+            }
+
+            if (input.tableContinuationToken == null)
+            {
+                throw new ArgumentNullException(nameof(input.tableContinuationToken));
+            }
+
+            var recipients = new List<SentNotificationDataEntity>();
+            while (input.tableContinuationToken != null && recipients.Count < MaxResultSize)
+            {
+                var results = await this.sentNotificationDataRepository.GetPagedAsync(input.notificationId, UserCount, input.tableContinuationToken);
+                if (results.Item1 != null)
+                {
+                    recipients.AddRange(results.Item1);
+                }
+
+                input.tableContinuationToken = results.Item2;
+            }
+
+            return (recipients, input.tableContinuationToken);
         }
 
         /// <summary>

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/FunctionNames.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/FunctionNames.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         public const string GetRecipientsActivity = nameof(GetRecipientsActivity);
 
         /// <summary>
+        /// Get recipients acitvity by token function.
+        /// </summary>
+        public const string GetRecipientsByTokenActivity = nameof(GetRecipientsByTokenActivity);
+
+        /// <summary>
         /// Get pending recipients (ie recipients with no conversation id in the database) acitvity function.
         /// </summary>
         public const string GetPendingRecipientsActivity = nameof(GetPendingRecipientsActivity);

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Orchestrators/SendQueueOrchestrator.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Orchestrators/SendQueueOrchestrator.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.Logging;
@@ -53,12 +54,28 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
                 log.LogInformation("About to get all recipients.");
             }
 
-            var recipients = await context.CallActivityWithRetryAsync<IEnumerable<SentNotificationDataEntity>>(
+            var results = await context.CallActivityWithRetryAsync<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)>(
                 FunctionNames.GetRecipientsActivity,
                 FunctionSettings.DefaultRetryOptions,
                 notification);
 
-            var recipientsList = recipients.ToList();
+            var recipientsList = new List<SentNotificationDataEntity>();
+            if (results.Item1 != null)
+            {
+                recipientsList.AddRange(results.Item1.ToList());
+            }
+
+            while (results.Item2 != null)
+            {
+                results = await context.CallActivityWithRetryAsync<(IEnumerable<SentNotificationDataEntity>, TableContinuationToken)>(
+                FunctionNames.GetRecipientsByTokenActivity,
+                FunctionSettings.DefaultRetryOptions,
+                (notification.Id, results.Item2));
+                if (results.Item1 != null)
+                {
+                    recipientsList.AddRange(results.Item1);
+                }
+            }
 
             if (!context.IsReplaying)
             {

--- a/Source/CompanyCommunicator/ClientApp/src/App.scss
+++ b/Source/CompanyCommunicator/ClientApp/src/App.scss
@@ -400,7 +400,6 @@
             position: relative;
             cursor: pointer;
             line-height: 1.7rem;
-            color: #484644;
             font-size: 1.2rem;
         }
     }

--- a/Source/CompanyCommunicator/ClientApp/src/components/NewMessage/newMessage.tsx
+++ b/Source/CompanyCommunicator/ClientApp/src/components/NewMessage/newMessage.tsx
@@ -329,7 +329,7 @@ class NewMessage extends React.Component<INewMessageProps, formState> {
             if (this.state.page === "CardCreation") {
                 return (
                     <div className="taskModule">
-                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                             <Flex className="scrollableContent">
                                 <Flex.Item size="size.half">
                                     <Flex column className="formContentContainer">
@@ -409,7 +409,7 @@ class NewMessage extends React.Component<INewMessageProps, formState> {
             else if (this.state.page === "AudienceSelection") {
                 return (
                     <div className="taskModule">
-                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                             <Flex className="scrollableContent">
                                 <Flex.Item size="size.half">
                                     <Flex column className="formContentContainer">

--- a/Source/CompanyCommunicator/ClientApp/src/components/SendConfirmationTaskModule/sendConfirmationTaskModule.tsx
+++ b/Source/CompanyCommunicator/ClientApp/src/components/SendConfirmationTaskModule/sendConfirmationTaskModule.tsx
@@ -140,7 +140,7 @@ class SendConfirmationTaskModule extends React.Component<SendConfirmationTaskMod
         } else {
             return (
                 <div className="taskModule">
-                    <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                    <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                         <Flex className="scrollableContent" gap="gap.small">
                             <Flex.Item size="size.half">
                                 <Flex column className="formContentContainer">

--- a/Source/CompanyCommunicator/ClientApp/src/components/StatusTaskModule/statusTaskModule.tsx
+++ b/Source/CompanyCommunicator/ClientApp/src/components/StatusTaskModule/statusTaskModule.tsx
@@ -145,7 +145,7 @@ class StatusTaskModule extends React.Component<StatusTaskModuleProps, IStatusSta
             if (this.state.page === "ViewStatus") {
                 return (
                     <div className="taskModule">
-                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                             <Flex className="scrollableContent">
                                 <Flex.Item size="size.half" className="formContentContainer">
                                     <Flex column>
@@ -214,7 +214,7 @@ class StatusTaskModule extends React.Component<StatusTaskModuleProps, IStatusSta
             else if (this.state.page === "SuccessPage") {
                 return (
                     <div className="taskModule">
-                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                             <div className="displayMessageField">
                                 <br />
                                 <br />
@@ -239,7 +239,7 @@ class StatusTaskModule extends React.Component<StatusTaskModuleProps, IStatusSta
             else {
                 return (
                     <div className="taskModule">
-                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small" styles={{ background: "white" }}>
+                        <Flex column className="formContainer" vAlign="stretch" gap="gap.small">
                             <div className="displayMessageField">
                                 <br />
                                 <br />

--- a/Source/Test/CompanyCommunicator.Prep.Func.Test/Export/Activities/GetMetadataActivityTest.cs
+++ b/Source/Test/CompanyCommunicator.Prep.Func.Test/Export/Activities/GetMetadataActivityTest.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.Export.Activit
     {
         private readonly Mock<IUsersService> usersService = new Mock<IUsersService>();
         private readonly Mock<IStringLocalizer<Strings>> localizer = new Mock<IStringLocalizer<Strings>>();
-        private readonly Mock<ILogger> log = new Mock<ILogger>();
 
         /// <summary>
         /// Gets RunParameters.

--- a/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/GetRecipientsActivityTest.cs
+++ b/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/GetRecipientsActivityTest.cs
@@ -7,10 +7,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
-    using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+    using Microsoft.Azure.Cosmos.Table;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.NotificationData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.SentNotificationData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend;
@@ -22,6 +21,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test
     /// </summary>
     public class GetRecipientsActivityTest
     {
+        private const int MaxResultSize = 100000;
+        private const int UserCount = 1000;
+
         private readonly Mock<ISentNotificationDataRepository> sentNotificationDataRepository = new Mock<ISentNotificationDataRepository>();
         private readonly string notificationId = "notificationId";
         private readonly IEnumerable<SentNotificationDataEntity> recipients = new List<SentNotificationDataEntity>()
@@ -58,15 +60,66 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test
             {
                 Id = this.notificationId,
             };
-            this.sentNotificationDataRepository.Setup(x => x.GetAllAsync(It.IsAny<string>(), null/*count*/))
-           .ReturnsAsync(this.recipients);
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((this.recipients, null));
 
             // Act
-            var recipientsList = await activity.GetRecipientsAsync(notificationObj);
+            var result = await activity.GetRecipientsAsync(notificationObj);
 
             // Assert
-            recipientsList.Should().HaveCount(2);
-            this.sentNotificationDataRepository.Verify(x => x.GetAllAsync(It.Is<string>(x => x.Equals(this.notificationId)), null /*count*/));
+            result.Item1.Should().HaveCount(2);
+            Assert.Null(result.Item2);
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<int>(), It.IsAny<TableContinuationToken>()));
+        }
+
+        /// <summary>
+        /// Get max recipients from repository.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task GetReceipients_ResultCount_ShouldNotExceedMaxResult()
+        {
+            // Arrange
+            var activity = this.GetRecipientsActivity();
+            NotificationDataEntity notificationObj = new NotificationDataEntity()
+            {
+                Id = this.notificationId,
+            };
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((this.GetRecipients(UserCount), new TableContinuationToken()));
+
+            // Act
+            var result = await activity.GetRecipientsAsync(notificationObj);
+
+            // Assert
+            result.Item1.Should().HaveCount(MaxResultSize);
+            Assert.NotNull(result.Item2);
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<int>(), It.IsAny<TableContinuationToken>()));
+        }
+
+        /// <summary>
+        /// Test if empty list is returned if no data is present.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task GetReceipients_NullData_ShouldReturnEmpty()
+        {
+            // Arrange
+            var activity = this.GetRecipientsActivity();
+            NotificationDataEntity notificationObj = new NotificationDataEntity()
+            {
+                Id = this.notificationId,
+            };
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((It.IsAny<List<SentNotificationDataEntity>>(), It.IsAny<TableContinuationToken>()));
+
+            // Act
+            var result = await activity.GetRecipientsAsync(notificationObj);
+
+            // Assert
+            Assert.Empty(result.Item1);
+            Assert.Null(result.Item2);
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<int>(), It.IsAny<TableContinuationToken>()));
         }
 
         /// <summary>
@@ -78,15 +131,77 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test
         {
             // Arrange
             var activity = this.GetRecipientsActivity();
-            this.sentNotificationDataRepository.Setup(x => x.GetAllAsync(It.IsAny<string>(), It.IsAny<int>()))
-           .ReturnsAsync(this.recipients);
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((this.recipients, null));
 
             // Act
             Func<Task> task = async () => await activity.GetRecipientsAsync(null /*notification*/);
 
             // Assert
             await task.Should().ThrowAsync<ArgumentNullException>("notification is null");
-            this.sentNotificationDataRepository.Verify(x => x.GetAllAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never());
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()), Times.Never());
+        }
+
+        /// <summary>
+        /// Get max recipients from repository.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task GetReceipientsyToken_ResultCount_ShouldNotExceedMaxResult()
+        {
+            // Arrange
+            var activity = this.GetRecipientsActivity();
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((this.GetRecipients(UserCount), new TableContinuationToken()));
+
+            // Act
+            var result = await activity.GetRecipientsByTokenAsync((this.notificationId, new TableContinuationToken()));
+
+            // Assert
+            result.Item1.Should().HaveCount(MaxResultSize);
+            Assert.NotNull(result.Item2);
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<int>(), It.IsAny<TableContinuationToken>()));
+        }
+
+        /// <summary>
+        /// Test if empty list is returned if no data is present.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task GetReceipientsByToken_NullData_ShouldReturnEmpty()
+        {
+            // Arrange
+            var activity = this.GetRecipientsActivity();
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((It.IsAny<List<SentNotificationDataEntity>>(), It.IsAny<TableContinuationToken>()));
+
+            // Act
+            var result = await activity.GetRecipientsByTokenAsync((this.notificationId, new TableContinuationToken()));
+
+            // Assert
+            Assert.Empty(result.Item1);
+            Assert.Null(result.Item2);
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<int>(), It.IsAny<TableContinuationToken>()));
+        }
+
+        /// <summary>
+        /// Test for Get Recipients Activity By Token failed when token is null.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        public async Task GetActivityByToken_NullToken_ShouldThrowNullException()
+        {
+            // Arrange
+            var activity = this.GetRecipientsActivity();
+            this.sentNotificationDataRepository.Setup(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()))
+           .ReturnsAsync((this.recipients, null));
+
+            // Act
+            Func<Task> task = async () => await activity.GetRecipientsByTokenAsync((this.notificationId, null /*token*/));
+
+            // Assert
+            await task.Should().ThrowAsync<ArgumentNullException>();
+            this.sentNotificationDataRepository.Verify(x => x.GetPagedAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<TableContinuationToken>()), Times.Never());
         }
 
         /// <summary>
@@ -140,6 +255,17 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test
         private GetRecipientsActivity GetRecipientsActivity()
         {
             return new GetRecipientsActivity(this.sentNotificationDataRepository.Object);
+        }
+
+        private List<SentNotificationDataEntity> GetRecipients(int count)
+        {
+            var entities = new List<SentNotificationDataEntity>();
+            for (int i = 0; i < count; i++)
+            {
+                entities.Add(new SentNotificationDataEntity { RecipientId = string.Format("test_{0}", i) });
+            }
+
+            return entities;
         }
     }
 }


### PR DESCRIPTION
This PR includes below changes :

- The GetRecipientsActivity is changed to handle paged db data and will return token if more data is available.The activity response is capped at 100000 users. This will ensure we don't run into serialization issues and can handle large audiences.
- Fixing theme issues.