### PR TITLE
Add image enlarge option and full width for messages

### DIFF
--- a/Source/CompanyCommunicator.Common/Services/AdaptiveCard/AdaptiveCardCreator.cs
+++ b/Source/CompanyCommunicator.Common/Services/AdaptiveCard/AdaptiveCardCreator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AdaptiveCardCreator.cs" company="Microsoft">
+// <copyright file="AdaptiveCardCreator.cs" company="Microsoft">
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
@@ -61,13 +61,18 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.AdaptiveCard
 
             if (!string.IsNullOrWhiteSpace(imageUrl))
             {
-                card.Body.Add(new AdaptiveImage()
+                var img = new AdaptiveImage()
                 {
                     Url = new Uri(imageUrl, UriKind.RelativeOrAbsolute),
                     Spacing = AdaptiveSpacing.Default,
                     Size = AdaptiveImageSize.Stretch,
                     AltText = string.Empty,
-                });
+                };
+
+                // Image enlarge support for Teams web/desktop client.
+                img.AdditionalProperties.Add("msteams", new { AllowExpand = true });
+
+                card.Body.Add(img);
             }
 
             if (!string.IsNullOrWhiteSpace(summary))
@@ -99,6 +104,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.AdaptiveCard
                     Url = new Uri(buttonUrl, UriKind.RelativeOrAbsolute),
                 });
             }
+
+            // Full Width Adaptive Card.
+            card.AdditionalProperties.Add("msteams", new { width = "full" });
 
             return card;
         }


### PR DESCRIPTION
**Summary**
For company-wide communications, the message real estate should be perfect for all devices, mobile, web, and desktop. Most office workers nowadays have wide screens. 

This PR has several improvements for web/desktop clients:
- Image enlarge support for Teams web/desktop client. 
- Zoom in and zoom out capability for the image in an Adaptive card.
- Full width Adaptive card

**Implementation details**

- For Teams mobile client, stage view functionality (enlarge, zoom in/out) for images in Adaptive Cards are available by default and users will be able to view Adaptive card images in stage view by simply tapping on the image. For Teams web/desktop clients we should use the special allowExpand attribute. 
- To make a full width Adaptive card the width object in msteams property in the card content must be set to Full.
