### PR TITLE
Image upload v2

### DIFF
--- a/Source/CompanyCommunicator.Common/Repositories/NotificationData/NotificationDataEntity.cs
+++ b/Source/CompanyCommunicator.Common/Repositories/NotificationData/NotificationDataEntity.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.Notificat
         /// Gets or sets the image link of the notification's content.
         /// </summary>
         public string ImageLink { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the blob name for the image.
+        /// </summary>
+        public string ImageBlobName { get; set; }
 
         /// <summary>
         /// Gets or sets the summary text of the notification's content.


### PR DESCRIPTION
You can securely upload up to 1024X1024px (<1 Mb) images without reducing quality. Just a placeholder for now since #382 should be merged before. 