### PR TITLE
Fix for the issue - CC sends 1:1 messages to guest users from different tenants

### DIFF
--- a/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/TeamWork/AppManagerService.cs
+++ b/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/TeamWork/AppManagerService.cs
@@ -50,12 +50,18 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
                 },
             };
 
-            await this.graphServiceClient.Users[userId]
+            // Skip Guest users.
+            var user = await this.graphServiceClient.Users[userId].Request().GetAsync();
+            if (!string.Equals(user.UserType, "Guest", StringComparison.OrdinalIgnoreCase)
+                && !user.UserPrincipalName.ToLower().Contains("#ext#"))
+            {
+                await this.graphServiceClient.Users[userId]
                 .Teamwork
                 .InstalledApps
                 .Request()
                 .WithMaxRetry(GraphConstants.MaxRetry)
                 .AddAsync(userScopeTeamsAppInstallation);
+            }
         }
 
         /// <inheritdoc/>

--- a/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
+++ b/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
@@ -119,7 +119,10 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
                     continuationToken,
                     cancellationToken);
                 continuationToken = currentPage.ContinuationToken;
-                members.AddRange(currentPage.Members);
+
+                // Skip Guest users.
+                var membersWithoutGuests = currentPage.Members.Where(member => !member.UserPrincipalName.ToLower().Contains("#ext#"));
+                members.AddRange(membersWithoutGuests);
             }
             while (continuationToken != null && !cancellationToken.IsCancellationRequested);
 

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncGroupMembersActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncGroupMembersActivity.cs
@@ -117,16 +117,20 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             var maxParallelism = Math.Min(100, users.Count());
             await Task.WhenAll(users.ForEachAsync(maxParallelism, async user =>
             {
-                var userEntity = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.Id);
-                if (userEntity == null)
+                // Skip Guest users.
+                if (!user.UserPrincipalName.ToLower().Contains("#ext#"))
                 {
-                    userEntity = new UserDataEntity()
+                    var userEntity = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.Id);
+                    if (userEntity == null)
                     {
-                        AadId = user.Id,
-                    };
-                }
+                        userEntity = new UserDataEntity()
+                        {
+                            AadId = user.Id,
+                        };
+                    }
 
-                recipients.Add(userEntity.CreateInitialSentNotificationDataEntity(partitionKey: notificationId));
+                    recipients.Add(userEntity.CreateInitialSentNotificationDataEntity(partitionKey: notificationId));
+                }
             }));
 
             return recipients;

--- a/Source/CompanyCommunicator/Bot/TeamsDataCapture.cs
+++ b/Source/CompanyCommunicator/Bot/TeamsDataCapture.cs
@@ -7,8 +7,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Bot
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Teams;
     using Microsoft.Bot.Schema;
+    using Microsoft.Bot.Schema.Teams;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.TeamData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
@@ -45,9 +49,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Bot
         /// <summary>
         /// Add channel or personal data in Table Storage.
         /// </summary>
-        /// <param name="activity">Teams activity instance.</param>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// /// <param name="activity">Teams activity instance.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        public async Task OnBotAddedAsync(IConversationUpdateActivity activity)
+        public async Task OnBotAddedAsync(ITurnContext turnContext, IConversationUpdateActivity activity, CancellationToken cancellationToken)
         {
             // Take action if the event includes the bot being added.
             var membersAdded = activity.MembersAdded;
@@ -62,7 +69,13 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Bot
                     await this.teamDataRepository.SaveTeamDataAsync(activity);
                     break;
                 case TeamsDataCapture.PersonalType:
-                    await this.userDataService.SaveUserDataAsync(activity);
+                    // Skip Guest users.
+                    TeamsChannelAccount teamsUser = await TeamsInfo.GetMemberAsync(turnContext, activity.Recipient.Id, cancellationToken);
+                    if (!teamsUser.UserPrincipalName.ToLower().Contains("#ext#"))
+                    {
+                        await this.userDataService.SaveUserDataAsync(activity);
+                    }
+
                     break;
                 default: break;
             }

--- a/Source/CompanyCommunicator/Bot/TeamsDataCapture.cs
+++ b/Source/CompanyCommunicator/Bot/TeamsDataCapture.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Bot
         /// Add channel or personal data in Table Storage.
         /// </summary>
         /// <param name="turnContext">The context object for this turn.</param>
-        /// /// <param name="activity">Teams activity instance.</param>
+        /// <param name="activity">Teams activity instance.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A task that represents the work queued to execute.</returns>

--- a/Source/CompanyCommunicator/Bot/UserTeamsActivityHandler.cs
+++ b/Source/CompanyCommunicator/Bot/UserTeamsActivityHandler.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Bot
 
             if (activity.MembersAdded != null)
             {
-                await this.teamsDataCapture.OnBotAddedAsync(activity);
+                await this.teamsDataCapture.OnBotAddedAsync(turnContext, activity, cancellationToken);
             }
 
             if (activity.MembersRemoved != null)


### PR DESCRIPTION
According to [documentation](https://github.com/OfficeDev/microsoft-teams-apps-company-communicator/wiki/Frequently-Asked-Questions-(FAQ)#are-messages-sent-to-guest-users), you have the following statement: 
```
Are messages sent to guest users?
No, guest users are excluded from receiving messages. Note that they will still be able to view messages posted to a channel.
```

However, in several cases, CC sends 1:1 messages to guest users from different tenants. 

### Steps to reproduce:
Case 1:
1. Add a user app to a team1 with guests.
2. Select an option to send a 1:1 message for team1/group1.
3. Send to team1/group1 members 1:1 message. 

Actual result:
All guest users from team1/group1 received 1:1 messages from CC.

Expected result:
Guest users are excluded from receiving messages.

Case 2 (has to be run after case 1):
1. Select an option to send in chat to everyone 1:1 message, 
2. Send a message.

Actual result:
All guest users from team1/group1 received a message from CC.

Expected result:
Guest users are excluded from receiving messages.

The same issue occurs if we select the option "Send in chat to members of the following M365 groups, Distribution groups or Security groups".
The same issue occurs if we rolling out CC via Team Org-Wide policy.

### Environment:
CCv4.1 installed with default settings from the master branch. The organization has teams/groups with guest users.

