### PR TITLE
Remove guest records in the next round of sync for all users.

### DIFF
--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncAllUsersActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncAllUsersActivity.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         private async Task ProcessUserAsync(User user)
         {
             // Delete users who were removed.
-            if (user.AdditionalData?.ContainsKey("@removed") == true)
+            if (user.AdditionalData?.ContainsKey("@removed") == true || string.Equals(user.UserType, "Guest", StringComparison.OrdinalIgnoreCase))
             {
                 var localUser = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.Id);
                 if (localUser != null)


### PR DESCRIPTION
1. Sync to get the latest version deployed.
2. Remove manually just one record with partition key **UsersSyncData** from **UserData table**.
![image](https://user-images.githubusercontent.com/11201670/122204017-4d7f9800-cea7-11eb-9e80-567323dea498.png)
3. Send a message to all => Guests should NOT receive the message. All guest users should be removed forever from the **UserData** table automatically.