### PR TITLE
Suppress guest users when sending messages

### DIFF
--- a/Source/CompanyCommunicator.Common/Extensions/UserExtensions.cs
+++ b/Source/CompanyCommunicator.Common/Extensions/UserExtensions.cs
@@ -3,9 +3,12 @@
 // Licensed under the MIT License.
 // </copyright>
 
-namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Extensions
+namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Extensions
 {
+    using System;
     using System.Collections.Generic;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
 
     /// <summary>
     /// Extensions for User Ids.
@@ -39,6 +42,21 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Extensions
             {
                 yield return buffer;
             }
+        }
+
+        /// <summary>
+        /// Get the user type for a user.
+        /// </summary>
+        /// <param name="userPrincipalName">the user principal name.</param>
+        /// <returns>the user type such as Member or Guest.</returns>
+        public static string GetUserType(this string userPrincipalName)
+        {
+            if (string.IsNullOrEmpty(userPrincipalName))
+            {
+                throw new ArgumentNullException(nameof(userPrincipalName));
+            }
+
+            return userPrincipalName.ToLower().Contains("#ext#") ? UserType.Guest : UserType.Member;
         }
     }
 }

--- a/Source/CompanyCommunicator.Common/Repositories/UserData/UserDataEntity.cs
+++ b/Source/CompanyCommunicator.Common/Repositories/UserData/UserDataEntity.cs
@@ -54,5 +54,10 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData
         /// Gets or sets the tenant id for the user.
         /// </summary>
         public string TenantId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user type i.e. Member or Guest.
+        /// </summary>
+        public string UserType { get; set; }
     }
 }

--- a/Source/CompanyCommunicator.Common/Resources/Strings.Designer.cs
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.Designer.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User Type.
+        /// </summary>
+        public static string ColumnName_UserType {
+            get {
+                return ResourceManager.GetString("ColumnName_UserType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} (copy).
         /// </summary>
         public static string DuplicateText {
@@ -363,6 +372,24 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources {
         public static string FileUploadErrorText {
             get {
                 return ResourceManager.GetString("FileUploadErrorText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Guest.
+        /// </summary>
+        public static string Guest {
+            get {
+                return ResourceManager.GetString("Guest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Member.
+        /// </summary>
+        public static string Member {
+            get {
+                return ResourceManager.GetString("Member", resourceCulture);
             }
         }
         

--- a/Source/CompanyCommunicator.Common/Resources/Strings.ar-SA.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.ar-SA.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>مقيّد</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>User Type</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Guest</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Member</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.de-DE.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.de-DE.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Gedrosselt</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>Benutzertyp</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Gast</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Mitglied</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.es-ES.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.es-ES.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Limitado</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>User Type</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Guest</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Member</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.fr-FR.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.fr-FR.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Limité</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>Type d'utilisateur</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Invité</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Membre</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.he-IL.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.he-IL.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>מווסת</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>סוג משתמש</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>אורח</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>חבר</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.ja-JP.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.ja-JP.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>調整済み</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>ユーザーの種類</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>ゲスト</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>メンバー</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.ko-KR.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.ko-KR.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>제한됨</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>사용자 유형</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>게스트</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>구성원</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.pt-BR.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.pt-BR.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Limitado</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>User Type</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Guest</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Member</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.qps-ploc.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.qps-ploc.resx
@@ -118,133 +118,142 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AdminConsentError" xml:space="preserve">
-    <value>_Cфптд©т убџґ ЇЋ дdмїп fфя pёгмїssїюп тю vїєщ тћїs dдтд.ЍѝцзджфЍ_</value>
+    <value>_Cбйтд©т чфџя ЇЋ дdмїл fфґ pёгмїssїюи тб vїзщ тнїs dдтд.ЍѝцзджфЍ_</value>
   </data>
   <data name="AppNotInstalled" xml:space="preserve">
-    <value>_Дpp Пфт ЇпsтдllёdЍѝц_</value>
+    <value>_Дpp Йфт ЇиsтдllзdЍѝц_</value>
   </data>
   <data name="ColumnName_DeliveryStatus" xml:space="preserve">
-    <value>_Dёlїvєґу SтдтцsЍѝ_</value>
+    <value>_Dэlїvёяу SтдтµsЍѝ_</value>
   </data>
   <data name="ColumnName_ExportedBy" xml:space="preserve">
-    <value>_Зжpбятзd ЪчЍѝ_</value>
+    <value>_Эжpбгтэd БчЍѝ_</value>
   </data>
   <data name="ColumnName_ExportTimeStamp" xml:space="preserve">
-    <value>_Зжpфят ЋїмзSтдмpЍѝ_</value>
+    <value>_Эжpфгт ЋїмэSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_MessageTitle" xml:space="preserve">
-    <value>_Mёssдgз ЋїтlэЍѝ_</value>
+    <value>_Mэssдgз ЋїтlёЍѝ_</value>
   </data>
   <data name="ColumnName_SentTimeStamp" xml:space="preserve">
-    <value>_Sэпт ЋїмзSтдмpЍѝ_</value>
+    <value>_Sєлт ЋїмёSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_StatusReason" xml:space="preserve">
-    <value>_Sтдтцs ЯёдsюпЍѝ_</value>
+    <value>_Sтдтµs ЃёдsюпЍѝ_</value>
   </data>
   <data name="ColumnName_TeamId" xml:space="preserve">
-    <value>_Ћэдм ЇDЍ_</value>
+    <value>_Ћёдм ЇDЍ_</value>
   </data>
   <data name="ColumnName_TeamName" xml:space="preserve">
-    <value>_Ћєдм ПдмёЍ_</value>
+    <value>_Ћёдм ИдмэЍ_</value>
   </data>
   <data name="ColumnName_Upn" xml:space="preserve">
-    <value>_ЦPЙ_</value>
+    <value>_ЦPП_</value>
   </data>
   <data name="ColumnName_UserId" xml:space="preserve">
-    <value>_Цsэя ЇDЍ_</value>
+    <value>_Џsєя ЇDЍ_</value>
   </data>
   <data name="ColumnName_UserName" xml:space="preserve">
-    <value>_ЙдмэЍ_</value>
+    <value>_ИдмёЍ_</value>
   </data>
   <data name="DuplicateText" xml:space="preserve">
-    <value>_{0} (©бpу)Ѝѝ_</value>
+    <value>_{0} (©фpу)Ѝѝ_</value>
   </data>
   <data name="ExportFailureText" xml:space="preserve">
-    <value>_Sюмэтнїлg щзлт шґюиg. Ћяч зжpюгтїлg тнз ґэsџlтs дgдїи.ЍѝцзджфЍ_</value>
+    <value>_Sбмэтћїпg щэлт шяюпg. Ћґч эжpбґтїйg тнё гёsµlтs дgдїй.ЍѝцзджфЍ_</value>
   </data>
   <data name="Failed" xml:space="preserve">
-    <value>_FдїlёdЍ_</value>
+    <value>_FдїlєdЍ_</value>
   </data>
   <data name="UserAppNotFound" xml:space="preserve">
-    <value>_Џsєг дpplї©дтїфп иют fбµиd. Mдќэ sцґє тнэ Цsэґ дpp їs µplюдdєd тб чфцґ бяgдпїzдтїфй's дpp ©дтдlбg.ЍѝцзджфЍѝцзджфЍ_</value>
+    <value>_Цsёя дpplї©дтїюй лбт fфцпd. Mдкё sџґз тћз Цsэг дpp їs µplбдdэd тб убџґ фґgдлїzдтїбл's дpp ©дтдlфg.ЍѝцзджфЍѝцзджфЍ_</value>
   </data>
   <data name="FailedToFindUserAppInAppCatalog" xml:space="preserve">
-    <value>_Fдїlєd тб fїиd тћє Цsзґ дpplї©дтїюп: {0} їй тћэ фгgдпїzдтїбл's дpp ©дтдlюg.ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlєd тю fїлd тћэ Џsэґ дpplї©дтїфй: {0} їй тнє югgдиїzдтїюл's дpp ©дтдlбg.ЍѝцзджфЍѝцз_</value>
     <comment>{0} - app Id. (GUID).</comment>
   </data>
   <data name="FailedToCreateConversationFormat" xml:space="preserve">
-    <value>_Fдїlєd тю ©яэдтє ©фиvёґsдтїюи. Ёяяюг мёssдgэ: {0}Ѝѝцзджф_</value>
+    <value>_Fдїlєd тф ©гёдтє ©блvзгsдтїюл. Єґябг мєssдgё: {0}Ѝѝцзджф_</value>
   </data>
   <data name="FailedToCreateConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlэd тф ©яёдтє ©блvёґsдтїюп шїтћ тёдмs џsэг: {0}. Єж©єpтїфи: {1}ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlєd тф ©гёдтз ©фиvєгsдтїби щїтћ тёдмs цsзя: {0}. Ёж©єpтїюи: {1}ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToCreateConversationThrottledFormt" xml:space="preserve">
-    <value>_Fдїlєd тб ©гэдтз ©бпvёґsдтїбл. Яєqцэsт тнґбттlёd. Єгґбя мєssдgє: {0}"ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlёd тф ©гэдтє ©бйvзгsдтїюй. Гёqµзsт тћгфттlэd. Єягюґ мєssдgё: {0}"ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToFindTeamInDbFormat" xml:space="preserve">
-    <value>_Fдїlэd тб fїйd тћз тздм {0} їи DЬ.Ѝѝцзд_</value>
+    <value>_Fдїlэd тф fїйd тнз тэдм {0} їй DЪ.Ѝѝцзд_</value>
   </data>
   <data name="FailedToGetAllUsersFormat" xml:space="preserve">
-    <value>_Fдїlёd тб sчп© дll џsёґs. Sтдтµs Cфdє: {0} Зж©ёpтїбл: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlэd тю sул© дll цsєяs. Sтдтџs Cфdз: {0} Ёж©зpтїфп: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailedToGetConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlзd тф gзт ©юйvєґsдтїфп їd fфґ µsєг: {0}. Sтдтµs Cбdз: {1} Зж©эpтїюл: {2}ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlзd тф gёт ©бпvєяsдтїюл їd fбг цsэґ: {0}. Sтдтµs Cюdє: {1} Эж©єpтїюл: {2}ЍѝцзджфЍѝцз_</value>
   </data>
   <data name="FailedToGetMembersForGroupFormat" xml:space="preserve">
-    <value>_Fдїlзd тб gэт мзмвзґs fбґ gгюџp {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlёd тф gёт мзмьзґs fфґ gгюџp {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToGetMembersForTeamFormat" xml:space="preserve">
-    <value>_Fдїlэd тб gзт мёмвзяs fбя тздм {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlёd тб gєт мэмъзґs fюг тэдм {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToInstallApplicationForUserFormat" xml:space="preserve">
-    <value>_Fдїlєd тб їйsтдll дpplї©дтїбй fбг цsзя: {0}. Єж©ёpтїюи: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlєd тб їиsтдll дpplї©дтїюй fюя џsєґ: {0}. Эж©эpтїфл: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailtoPrepareMessageFormat" xml:space="preserve">
-    <value>_Fдїlэd тф pґэpдґё тћз мэssдgз fбґ sэпdїпg:{0}Ѝѝцзджф_</value>
+    <value>_Fдїlэd тб pґзpдгэ тнё мёssдgє fфя sэлdїлg:{0}Ѝѝцзджф_</value>
   </data>
   <data name="FileCardDescription" xml:space="preserve">
-    <value>_Ћћїs fїlэ ©юлтдїпs тнё ґєsµlтs ўфџ ёжpфятёd.Ѝѝцзджф_</value>
+    <value>_Ћћїs fїlз ©фйтдїпs тнё ґёsџlтs ўфц ёжpбґтёd.Ѝѝцзджф_</value>
   </data>
   <data name="FileCardExpireText" xml:space="preserve">
-    <value>_Ћнё lїпќ fбя тћїs dфщйlюдd ћдs зжpїгёd. Зжpюят тнэ ґєsџlтs дgдїи.ЍѝцзджфЍѝц_</value>
+    <value>_Ћћё lїиќ fбг тћїs dфшйlюдd ндs зжpїяєd. Єжpюят тћё яёsцlтs дgдїп.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileName_ExportData" xml:space="preserve">
-    <value>_ЭжpюятDдтдЍѝ_</value>
+    <value>_ЄжpбятDдтдЍѝ_</value>
   </data>
   <data name="FileName_Message_Delivery" xml:space="preserve">
-    <value>_Mєssдgё_DэlїvєгчЍѝ_</value>
+    <value>_Mєssдgє_DэlїvзгуЍѝ_</value>
   </data>
   <data name="FileName_Metadata" xml:space="preserve">
-    <value>_MётдdдтдЍ_</value>
+    <value>_MзтдdдтдЍ_</value>
   </data>
   <data name="FileReadyText" xml:space="preserve">
-    <value>_Ўюџя fїlё їs гэдdў тф dюшпlюдd. Д ©фpу їs дlsф дvдїlдьlё їп ЮйзDгїvё.ЍѝцзджфЍѝц_</value>
+    <value>_Чфµг fїlэ їs яздdч тю dфшиlбдd. Д ©фpч їs дlsб дvдїlдъlэ їп ЮиэDяїvз.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileUploadErrorText" xml:space="preserve">
-    <value>_Sюмзтћїиg щэйт шґбйg. Ћяу зжpбґтїйg тнэ ґзsџlтs дgдїи.ЍѝцзджфЍ_</value>
+    <value>_Sюмєтћїлg щёлт щгбиg. Ћяч зжpюґтїиg тнз яэsцlтs дgдїи.ЍѝцзджфЍ_</value>
   </data>
   <data name="NumberOfGroupsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнз ифтїfї©дтїюп ћдs {0} gгюцps дs їтs гэ©їpїэйтs. Їт sнфµldй'т зж©ээd {1} gгюµps.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћћэ йбтїfї©дтїюи ндs {0} gяюµps дs їтs гё©їpїєйтs. Їт sнбџldл'т єж©эєd {1} gґбµps.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="NumberOfRostersExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнє пфтїfї©дтїфй ндs {0} гбsтзгs дs їтs ґэ©їpїёйтs. Їт sћбцldй'т эж©єзd {1} яюsтэяs.ЍѝцзджфЍѝцздж_</value>
+    <value>_Ћнё пбтїfї©дтїюй ндs {0} яфsтєґs дs їтs гз©їpїёптs. Їт sћфцldи'т єж©ззd {1} яюsтзгs.ЍѝцзджфЍѝцздж_</value>
   </data>
   <data name="NumberOfTeamsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнэ пютїfї©дтїбп ндs {0} тздмs дs їтs яз©їpїзлтs. Їт sнбџldй'т єж©єэd {1} тэдмs.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћнє лфтїfї©дтїюи ћдs {0} тєдмs дs їтs яє©їpїёйтs. Їт sнюџldи'т эж©єэd {1} тєдмs.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>_ЮЌ_</value>
   </data>
   <data name="PermissionDeclinedText" xml:space="preserve">
-    <value>_Pёямїssїюп dз©lїизd. Шэ щїll ифт pгф©зёd шїтн тћэ эжpфят.ЍѝцзджфЍѝ_</value>
+    <value>_Pзґмїssїбл dє©lїлёd. Шё шїll пбт pгб©ёэd шїтн тћё ёжpюгт.ЍѝцзджфЍѝ_</value>
   </data>
   <data name="RecipientNotFound" xml:space="preserve">
-    <value>_Гє©їpїэит Йбт FюџпdЍѝц_</value>
+    <value>_Ґз©їpїёит Ифт FфµйdЍѝц_</value>
   </data>
   <data name="Succeeded" xml:space="preserve">
-    <value>_Sµ©©ззdэdЍ_</value>
+    <value>_Sµ©©ёёdзdЍ_</value>
   </data>
   <data name="Throttled" xml:space="preserve">
-    <value>_ЋћґфттlэdЍ_</value>
+    <value>_ЋћябттlзdЍ_</value>
+  </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>_Цsэґ ЋўpэЍ_</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>_GµёsтЍ_</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>_MємьёяЍ_</value>
   </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.qps-ploca.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.qps-ploca.resx
@@ -118,133 +118,142 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AdminConsentError" xml:space="preserve">
-    <value>_Cюптд©т чюџя ЇЋ дdмїи fбг pэгмїssїюй тю vїэщ тћїs dдтд.ЍѝцзджфЍ_</value>
+    <value>_Cфлтд©т ўбµг ЇЋ дdмїл fфг pёгмїssїфп тю vїєщ тћїs dдтд.ЍѝцзджфЍ_</value>
   </data>
   <data name="AppNotInstalled" xml:space="preserve">
-    <value>_Дpp Лбт ЇпsтдllєdЍѝц_</value>
+    <value>_Дpp Лфт ЇлsтдllёdЍѝц_</value>
   </data>
   <data name="ColumnName_DeliveryStatus" xml:space="preserve">
-    <value>_Dзlїvзгў SтдтџsЍѝ_</value>
+    <value>_Dєlїvэяў SтдтцsЍѝ_</value>
   </data>
   <data name="ColumnName_ExportedBy" xml:space="preserve">
-    <value>_Ёжpбґтєd bуЍѝ_</value>
+    <value>_Єжpфятёd bўЍѝ_</value>
   </data>
   <data name="ColumnName_ExportTimeStamp" xml:space="preserve">
-    <value>_Эжpюгт ЋїмэSтдмpЍѝ_</value>
+    <value>_Зжpфгт ЋїмзSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_MessageTitle" xml:space="preserve">
-    <value>_Mэssдgз ЋїтlзЍѝ_</value>
+    <value>_Mєssдgё ЋїтlёЍѝ_</value>
   </data>
   <data name="ColumnName_SentTimeStamp" xml:space="preserve">
-    <value>_Sёлт ЋїмзSтдмpЍѝ_</value>
+    <value>_Sєлт ЋїмёSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_StatusReason" xml:space="preserve">
-    <value>_Sтдтџs ГэдsюйЍѝ_</value>
+    <value>_Sтдтµs ЯєдsблЍѝ_</value>
   </data>
   <data name="ColumnName_TeamId" xml:space="preserve">
-    <value>_Ћєдм ЇDЍ_</value>
+    <value>_Ћэдм ЇDЍ_</value>
   </data>
   <data name="ColumnName_TeamName" xml:space="preserve">
-    <value>_Ћєдм ЛдмёЍ_</value>
+    <value>_Ћздм ПдмзЍ_</value>
   </data>
   <data name="ColumnName_Upn" xml:space="preserve">
-    <value>_ЏPП_</value>
+    <value>_ЦPЛ_</value>
   </data>
   <data name="ColumnName_UserId" xml:space="preserve">
-    <value>_Цsёя ЇDЍ_</value>
+    <value>_Џsзг ЇDЍ_</value>
   </data>
   <data name="ColumnName_UserName" xml:space="preserve">
-    <value>_ЛдмэЍ_</value>
+    <value>_ЛдмєЍ_</value>
   </data>
   <data name="DuplicateText" xml:space="preserve">
     <value>_{0} (©юpу)Ѝѝ_</value>
   </data>
   <data name="ExportFailureText" xml:space="preserve">
-    <value>_Sфмётћїиg щёпт шґюиg. Ћяу єжpюятїйg тнэ ґєsµlтs дgдїй.ЍѝцзджфЍ_</value>
+    <value>_Sюмётнїпg шєйт щґюиg. Ћгч ёжpбятїлg тћз язsџlтs дgдїи.ЍѝцзджфЍ_</value>
   </data>
   <data name="Failed" xml:space="preserve">
     <value>_FдїlёdЍ_</value>
   </data>
   <data name="UserAppNotFound" xml:space="preserve">
-    <value>_Џsзг дpplї©дтїбп йбт fбцпd. Mдќэ sцґё тћэ Цsзг дpp їs µplфдdёd тб ўбµґ фяgдпїzдтїфл's дpp ©дтдlбg.ЍѝцзджфЍѝцзджфЍ_</value>
+    <value>_Цsєґ дpplї©дтїюй ифт fюцйd. Mдќэ sџґє тнз Џsёг дpp їs µplфдdєd тб ўюця фгgдйїzдтїфп's дpp ©дтдlфg.ЍѝцзджфЍѝцзджфЍ_</value>
   </data>
   <data name="FailedToFindUserAppInAppCatalog" xml:space="preserve">
-    <value>_Fдїlзd тб fїпd тћз Цsэг дpplї©дтїфй: {0} їп тћэ фґgдлїzдтїюл's дpp ©дтдlбg.ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlєd тю fїпd тнэ Џsзг дpplї©дтїюл: {0} їп тнє юґgдйїzдтїбл's дpp ©дтдlфg.ЍѝцзджфЍѝцз_</value>
     <comment>{0} - app Id. (GUID).</comment>
   </data>
   <data name="FailedToCreateConversationFormat" xml:space="preserve">
-    <value>_Fдїlзd тб ©ґєдтё ©юпvёгsдтїюл. Эґґфґ мєssдgэ: {0}Ѝѝцзджф_</value>
+    <value>_Fдїlэd тю ©яёдтэ ©фиvёгsдтїюй. Зґяфґ мэssдgё: {0}Ѝѝцзджф_</value>
   </data>
   <data name="FailedToCreateConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlэd тб ©гздтэ ©флvёяsдтїфй шїтн тэдмs цsєг: {0}. Зж©эpтїюл: {1}ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlэd тю ©ґздтё ©фиvзґsдтїюл шїтћ тэдмs џsзя: {0}. Эж©зpтїюл: {1}ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToCreateConversationThrottledFormt" xml:space="preserve">
-    <value>_Fдїlэd тю ©яздтз ©фйvёяsдтїфп. Ґэqцзsт тняюттlєd. Єягюґ мєssдgє: {0}"ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlєd тф ©яздтё ©фиvєгsдтїюп. Ѓзqџєsт тнгфттlзd. Эґгюг мёssдgэ: {0}"ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToFindTeamInDbFormat" xml:space="preserve">
-    <value>_Fдїlєd тю fїйd тнє тёдм {0} їй DЪ.Ѝѝцзд_</value>
+    <value>_Fдїlэd тю fїиd тнэ тздм {0} їп DБ.Ѝѝцзд_</value>
   </data>
   <data name="FailedToGetAllUsersFormat" xml:space="preserve">
-    <value>_Fдїlёd тб sуи© дll цsэґs. Sтдтџs Cбdє: {0} Зж©єpтїюй: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlєd тю sуп© дll µsзяs. Sтдтцs Cбdэ: {0} Ёж©эpтїфл: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailedToGetConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlзd тю gєт ©фпvэґsдтїфл їd fюя цsзґ: {0}. Sтдтµs Cфdє: {1} Єж©эpтїби: {2}ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlзd тб gёт ©бпvёґsдтїюй їd fфґ µsэг: {0}. Sтдтµs Cфdє: {1} Єж©ёpтїюй: {2}ЍѝцзджфЍѝцз_</value>
   </data>
   <data name="FailedToGetMembersForGroupFormat" xml:space="preserve">
-    <value>_Fдїlзd тб gёт мёмьёґs fбґ gґбџp {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlєd тб gзт мємьёяs fюг gґбџp {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToGetMembersForTeamFormat" xml:space="preserve">
-    <value>_Fдїlзd тю gзт мёмьёґs fбя тёдм {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlєd тю gєт мёмъэґs fюя тєдм {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToInstallApplicationForUserFormat" xml:space="preserve">
-    <value>_Fдїlэd тб їлsтдll дpplї©дтїюп fфґ µsзґ: {0}. Єж©эpтїбп: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlэd тю їиsтдll дpplї©дтїбп fбґ цsзґ: {0}. Эж©зpтїфп: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailtoPrepareMessageFormat" xml:space="preserve">
-    <value>_Fдїlэd тб pяёpдґз тћз мєssдgё fюя sзйdїйg:{0}Ѝѝцзджф_</value>
+    <value>_Fдїlєd тю pяёpдяэ тћэ мёssдgё fюг sэиdїйg:{0}Ѝѝцзджф_</value>
   </data>
   <data name="FileCardDescription" xml:space="preserve">
-    <value>_Ћнїs fїlэ ©бйтдїиs тћз ґєsџlтs ўбџ ёжpбґтєd.Ѝѝцзджф_</value>
+    <value>_Ћнїs fїlз ©юлтдїйs тнє яєsџlтs ўюџ ёжpбґтєd.Ѝѝцзджф_</value>
   </data>
   <data name="FileCardExpireText" xml:space="preserve">
-    <value>_Ћћє lїиќ fфг тћїs dфшлlюдd ћдs эжpїґёd. Эжpфгт тћз гэsџlтs дgдїл.ЍѝцзджфЍѝц_</value>
+    <value>_Ћћз lїиќ fфг тћїs dфшлlфдd ћдs єжpїгєd. Єжpюят тнё яэsµlтs дgдїи.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileName_ExportData" xml:space="preserve">
-    <value>_ЄжpбятDдтдЍѝ_</value>
+    <value>_ЗжpфгтDдтдЍѝ_</value>
   </data>
   <data name="FileName_Message_Delivery" xml:space="preserve">
-    <value>_Mзssдgэ_DзlїvёґчЍѝ_</value>
+    <value>_Mєssдgз_DєlїvэґўЍѝ_</value>
   </data>
   <data name="FileName_Metadata" xml:space="preserve">
-    <value>_MётдdдтдЍ_</value>
+    <value>_MэтдdдтдЍ_</value>
   </data>
   <data name="FileReadyText" xml:space="preserve">
-    <value>_Ўюця fїlз їs ґздdу тф dбшйlюдd. Д ©фpў їs дlsф дvдїlдъlэ їл ФпёDґїvз.ЍѝцзджфЍѝц_</value>
+    <value>_Уюџг fїlз їs гєдdў тю dфшлlбдd. Д ©фpу їs дlsф дvдїlдьlє їй ФлєDґїvз.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileUploadErrorText" xml:space="preserve">
-    <value>_Sбмзтнїиg шзит щяюйg. Ћґу эжpюгтїпg тћз ґзsџlтs дgдїй.ЍѝцзджфЍ_</value>
+    <value>_Sфмзтћїпg шэйт шгюлg. Ћґў эжpбгтїиg тћз ґёsµlтs дgдїп.ЍѝцзджфЍ_</value>
   </data>
   <data name="NumberOfGroupsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнэ лфтїfї©дтїюл ћдs {0} gґюцps дs їтs ґє©їpїэитs. Їт sћфџldл'т зж©эёd {1} gґбµps.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћћз пютїfї©дтїюи ћдs {0} gгбцps дs їтs ґэ©їpїёптs. Їт sћфµldй'т зж©ёєd {1} gґюµps.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="NumberOfRostersExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћћз пбтїfї©дтїфи ћдs {0} гбsтзяs дs їтs яє©їpїэптs. Їт sћюџldй'т зж©ёєd {1} ґюsтзгs.ЍѝцзджфЍѝцздж_</value>
+    <value>_Ћћз пбтїfї©дтїюй ндs {0} гфsтєяs дs їтs гє©їpїєитs. Їт sнюµldл'т зж©єёd {1} ґбsтэяs.ЍѝцзджфЍѝцздж_</value>
   </data>
   <data name="NumberOfTeamsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнє лбтїfї©дтїбл ндs {0} тэдмs дs їтs яё©їpїєптs. Їт sћфцldи'т єж©зєd {1} тэдмs.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћћё пбтїfї©дтїюп ћдs {0} тэдмs дs їтs ґз©їpїэитs. Їт sнюµldл'т єж©эзd {1} тєдмs.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="OK" xml:space="preserve">
     <value>_ФЌ_</value>
   </data>
   <data name="PermissionDeclinedText" xml:space="preserve">
-    <value>_Pзґмїssїбй dэ©lїйэd. Шє щїll пют pяб©эёd щїтн тћэ ёжpбгт.ЍѝцзджфЍѝ_</value>
+    <value>_Pёґмїssїюи dз©lїйёd. Щэ щїll лют pґб©єзd щїтн тћз єжpюгт.ЍѝцзджфЍѝ_</value>
   </data>
   <data name="RecipientNotFound" xml:space="preserve">
-    <value>_Гз©їpїэйт Ибт FюџлdЍѝц_</value>
+    <value>_Ґз©їpїєпт Йют FбцпdЍѝц_</value>
   </data>
   <data name="Succeeded" xml:space="preserve">
-    <value>_Sџ©©ёзdэdЍ_</value>
+    <value>_Sµ©©ёзdёdЍ_</value>
   </data>
   <data name="Throttled" xml:space="preserve">
-    <value>_ЋняюттlзdЍ_</value>
+    <value>_ЋнгфттlэdЍ_</value>
+  </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>_Цsёя ЋуpёЍ_</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>_GцёsтЍ_</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>_MємьёгЍ_</value>
   </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.qps-plocm.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.qps-plocm.resx
@@ -118,133 +118,142 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AdminConsentError" xml:space="preserve">
-    <value>_Cюптд©т ўбцґ ЇЋ дdмїи fюя pёгмїssїфи тф vїєш тнїs dдтд.ЍѝцзджфЍ_</value>
+    <value>_Cфлтд©т чюџґ ЇЋ дdмїп fбг pёгмїssїюи тб vїзш тћїs dдтд.ЍѝцзджфЍ_</value>
   </data>
   <data name="AppNotInstalled" xml:space="preserve">
-    <value>_Дpp Лфт ЇпsтдllёdЍѝц_</value>
+    <value>_Дpp Иют ЇлsтдllєdЍѝц_</value>
   </data>
   <data name="ColumnName_DeliveryStatus" xml:space="preserve">
-    <value>_Dэlїvёгў SтдтµsЍѝ_</value>
+    <value>_Dэlїvзяу SтдтµsЍѝ_</value>
   </data>
   <data name="ColumnName_ExportedBy" xml:space="preserve">
-    <value>_Зжpфґтєd БуЍѝ_</value>
+    <value>_Ёжpфґтзd БуЍѝ_</value>
   </data>
   <data name="ColumnName_ExportTimeStamp" xml:space="preserve">
-    <value>_Зжpфят ЋїмзSтдмpЍѝ_</value>
+    <value>_Ёжpюгт ЋїмэSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_MessageTitle" xml:space="preserve">
     <value>_Mзssдgэ ЋїтlзЍѝ_</value>
   </data>
   <data name="ColumnName_SentTimeStamp" xml:space="preserve">
-    <value>_Sэлт ЋїмёSтдмpЍѝ_</value>
+    <value>_Sэпт ЋїмзSтдмpЍѝ_</value>
   </data>
   <data name="ColumnName_StatusReason" xml:space="preserve">
-    <value>_Sтдтµs ЃєдsбйЍѝ_</value>
+    <value>_Sтдтцs ҐєдsфлЍѝ_</value>
   </data>
   <data name="ColumnName_TeamId" xml:space="preserve">
-    <value>_Ћздм ЇDЍ_</value>
+    <value>_Ћёдм ЇDЍ_</value>
   </data>
   <data name="ColumnName_TeamName" xml:space="preserve">
-    <value>_Ћёдм ИдмёЍ_</value>
+    <value>_Ћэдм ЙдмзЍ_</value>
   </data>
   <data name="ColumnName_Upn" xml:space="preserve">
-    <value>_ЏPП_</value>
+    <value>_ЦPИ_</value>
   </data>
   <data name="ColumnName_UserId" xml:space="preserve">
-    <value>_Цsзґ ЇDЍ_</value>
+    <value>_Цsёґ ЇDЍ_</value>
   </data>
   <data name="ColumnName_UserName" xml:space="preserve">
-    <value>_ЙдмэЍ_</value>
+    <value>_ПдмёЍ_</value>
   </data>
   <data name="DuplicateText" xml:space="preserve">
     <value>_{0} (©фpу)Ѝѝ_</value>
   </data>
   <data name="ExportFailureText" xml:space="preserve">
-    <value>_Sюмзтнїлg шєлт щгюйg. Ћяу эжpюятїлg тнє яэsџlтs дgдїй.ЍѝцзджфЍ_</value>
+    <value>_Sюмэтћїпg шзпт щґфлg. Ћгч эжpюгтїиg тнє яєsџlтs дgдїп.ЍѝцзджфЍ_</value>
   </data>
   <data name="Failed" xml:space="preserve">
     <value>_FдїlєdЍ_</value>
   </data>
   <data name="UserAppNotFound" xml:space="preserve">
-    <value>_Цsёґ дpplї©дтїбй лбт fбµпd. Mдкэ sџгз тћє Цsєя дpp їs µplфдdзd тю ўюџг юґgдпїzдтїюл's дpp ©дтдlюg.ЍѝцзджфЍѝцзджфЍ_</value>
+    <value>_Џsєя дpplї©дтїбп ибт fюциd. Mдкє sџяз тнё Џsёґ дpp їs џplюдdєd тб ўюцг фгgдиїzдтїфп's дpp ©дтдlюg.ЍѝцзджфЍѝцзджфЍ_</value>
   </data>
   <data name="FailedToFindUserAppInAppCatalog" xml:space="preserve">
-    <value>_Fдїlэd тб fїиd тнэ Џsєґ дpplї©дтїфй: {0} їп тћё юґgдлїzдтїбп's дpp ©дтдlбg.ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlзd тф fїлd тнэ Џsєґ дpplї©дтїфй: {0} їл тћз бґgдйїzдтїфп's дpp ©дтдlфg.ЍѝцзджфЍѝцз_</value>
     <comment>{0} - app Id. (GUID).</comment>
   </data>
   <data name="FailedToCreateConversationFormat" xml:space="preserve">
-    <value>_Fдїlёd тф ©ґэдтє ©фйvєяsдтїфй. Єяґбя мзssдgє: {0}Ѝѝцзджф_</value>
+    <value>_Fдїlэd тб ©гёдтє ©фйvёяsдтїби. Зяґюг мёssдgє: {0}Ѝѝцзджф_</value>
   </data>
   <data name="FailedToCreateConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlзd тб ©яєдтэ ©бпvёяsдтїфй щїтн тёдмs џsзя: {0}. Зж©ёpтїюй: {1}ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlёd тб ©гєдтэ ©юлvєгsдтїюи шїтн тздмs џsєя: {0}. Єж©зpтїюй: {1}ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToCreateConversationThrottledFormt" xml:space="preserve">
-    <value>_Fдїlэd тф ©гздтє ©фпvёяsдтїюл. Гзqµэsт тнгбттlзd. Єґябг мэssдgё: {0}"ЍѝцзджфЍѝц_</value>
+    <value>_Fдїlєd тб ©гэдтз ©фйvёяsдтїфл. Яэqџзsт тћгфттlёd. Єяяюг мзssдgз: {0}"ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FailedToFindTeamInDbFormat" xml:space="preserve">
-    <value>_Fдїlєd тю fїиd тћэ тздм {0} їи DЬ.Ѝѝцзд_</value>
+    <value>_Fдїlзd тю fїлd тћё тздм {0} їп Db.Ѝѝцзд_</value>
   </data>
   <data name="FailedToGetAllUsersFormat" xml:space="preserve">
-    <value>_Fдїlзd тф sул© дll µsєґs. Sтдтцs Cюdє: {0} Эж©єpтїфл: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlєd тю sчл© дll цsёґs. Sтдтцs Cбdэ: {0} Зж©ёpтїфп: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailedToGetConversationForUserFormat" xml:space="preserve">
-    <value>_Fдїlэd тб gзт ©юйvэяsдтїюл їd fюґ µsзя: {0}. Sтдтцs Cбdэ: {1} Єж©зpтїюл: {2}ЍѝцзджфЍѝцз_</value>
+    <value>_Fдїlзd тф gєт ©бйvзяsдтїбл їd fюґ цsэг: {0}. Sтдтџs Cбdє: {1} Єж©зpтїюй: {2}ЍѝцзджфЍѝцз_</value>
   </data>
   <data name="FailedToGetMembersForGroupFormat" xml:space="preserve">
-    <value>_Fдїlёd тф gзт мємъєґs fюя gґбµp {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlэd тб gєт мзмъєгs fюя gгбцp {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToGetMembersForTeamFormat" xml:space="preserve">
-    <value>_Fдїlёd тф gєт мэмвэгs fфґ тёдм {0}: {1}Ѝѝцздж_</value>
+    <value>_Fдїlєd тф gёт мёмьєяs fфг тёдм {0}: {1}Ѝѝцздж_</value>
   </data>
   <data name="FailedToInstallApplicationForUserFormat" xml:space="preserve">
-    <value>_Fдїlзd тб їпsтдll дpplї©дтїфл fюя µsэг: {0}. Ёж©єpтїбй: {1}ЍѝцзджфЍѝ_</value>
+    <value>_Fдїlёd тф їпsтдll дpplї©дтїфл fбя џsєг: {0}. Зж©эpтїбл: {1}ЍѝцзджфЍѝ_</value>
   </data>
   <data name="FailtoPrepareMessageFormat" xml:space="preserve">
-    <value>_Fдїlёd тф pгэpдґз тћэ мэssдgё fюґ sэйdїйg:{0}Ѝѝцзджф_</value>
+    <value>_Fдїlзd тф pяєpдґз тнэ мзssдgё fюг sэлdїпg:{0}Ѝѝцзджф_</value>
   </data>
   <data name="FileCardDescription" xml:space="preserve">
-    <value>_Ћнїs fїlэ ©юптдїйs тћє ґэsцlтs убџ зжpюгтёd.Ѝѝцзджф_</value>
+    <value>_Ћћїs fїlз ©юлтдїпs тнз ґєsцlтs чюц єжpфґтєd.Ѝѝцзджф_</value>
   </data>
   <data name="FileCardExpireText" xml:space="preserve">
-    <value>_Ћнэ lїиќ fюя тнїs dфщпlюдd ндs зжpїгзd. Ёжpфгт тћє гзsџlтs дgдїи.ЍѝцзджфЍѝц_</value>
+    <value>_Ћнэ lїпк fфґ тнїs dющйlбдd ћдs эжpїґэd. Єжpбґт тћё язsµlтs дgдїи.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileName_ExportData" xml:space="preserve">
-    <value>_ЭжpбґтDдтдЍѝ_</value>
+    <value>_ЭжpфґтDдтдЍѝ_</value>
   </data>
   <data name="FileName_Message_Delivery" xml:space="preserve">
-    <value>_Mзssдgє_DєlїvзячЍѝ_</value>
+    <value>_Mёssдgз_DєlїvёґчЍѝ_</value>
   </data>
   <data name="FileName_Metadata" xml:space="preserve">
     <value>_MэтдdдтдЍ_</value>
   </data>
   <data name="FileReadyText" xml:space="preserve">
-    <value>_Ўбцг fїlэ їs ґєдdч тф dфщйlюдd. Д ©юpу їs дlsб дvдїlдъlэ їи ЮпзDяїvз.ЍѝцзджфЍѝц_</value>
+    <value>_Ўбџґ fїlё їs гєдdў тб dбшиlбдd. Д ©бpч їs дlsф дvдїlдъlё їй ЮиёDґїvз.ЍѝцзджфЍѝц_</value>
   </data>
   <data name="FileUploadErrorText" xml:space="preserve">
-    <value>_Sюмэтћїйg щєлт шяюйg. Ћяу ёжpбгтїлg тћё гєsµlтs дgдїй.ЍѝцзджфЍ_</value>
+    <value>_Sфмєтнїлg шёйт шгбйg. Ћґч эжpфгтїлg тћє ґэsµlтs дgдїп.ЍѝцзджфЍ_</value>
   </data>
   <data name="NumberOfGroupsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћнэ лютїfї©дтїбл ћдs {0} gгфџps дs їтs яз©їpїэитs. Їт sнфцldп'т ёж©ёєd {1} gябџps.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћћэ пфтїfї©дтїфи ћдs {0} gґюџps дs їтs ґэ©їpїєлтs. Їт sнбцldп'т зж©зэd {1} gяфцps.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="NumberOfRostersExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћћє лбтїfї©дтїбп ћдs {0} яюsтёґs дs їтs ґё©їpїєйтs. Їт sнфµldи'т эж©зєd {1} ґюsтєяs.ЍѝцзджфЍѝцздж_</value>
+    <value>_Ћћэ ибтїfї©дтїфп ћдs {0} ґфsтэґs дs їтs ґё©їpїєитs. Їт sнбцldй'т єж©ёёd {1} гфsтєгs.ЍѝцзджфЍѝцздж_</value>
   </data>
   <data name="NumberOfTeamsExceededLimitWarningFormat" xml:space="preserve">
-    <value>_Ћћз пфтїfї©дтїбп ћдs {0} тэдмs дs їтs ґё©їpїэитs. Їт sћфµldи'т эж©зёd {1} тєдмs.ЍѝцзджфЍѝцзд_</value>
+    <value>_Ћћэ йютїfї©дтїфй ндs {0} тєдмs дs їтs ґэ©їpїэитs. Їт sнбцldи'т ёж©єёd {1} тєдмs.ЍѝцзджфЍѝцзд_</value>
   </data>
   <data name="OK" xml:space="preserve">
-    <value>_ФЌ_</value>
+    <value>_ЮЌ_</value>
   </data>
   <data name="PermissionDeclinedText" xml:space="preserve">
-    <value>_Pєгмїssїюй dэ©lїиєd. Шз шїll лбт pгю©зэd шїтћ тћє ёжpбґт.ЍѝцзджфЍѝ_</value>
+    <value>_Pэгмїssїби dё©lїйєd. Шє шїll йют pяю©зёd щїтћ тнз эжpюят.ЍѝцзджфЍѝ_</value>
   </data>
   <data name="RecipientNotFound" xml:space="preserve">
-    <value>_Гє©їpїзит Лют FфџиdЍѝц_</value>
+    <value>_Ґз©їpїёйт Лют FфџлdЍѝц_</value>
   </data>
   <data name="Succeeded" xml:space="preserve">
-    <value>_Sµ©©эзdэdЍ_</value>
+    <value>_Sџ©©зєdєdЍ_</value>
   </data>
   <data name="Throttled" xml:space="preserve">
-    <value>_ЋћяфттlєdЍ_</value>
+    <value>_ЋнґбттlэdЍ_</value>
+  </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>_Џsзг ЋчpєЍ_</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>_GцзsтЍ_</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>_MёмвёяЍ_</value>
   </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Throttled</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>User Type</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Guest</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Member</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.ru-RU.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.ru-RU.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>Отрегулировано</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>Тип пользователя</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>Гость</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>Участник</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.zh-CN.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.zh-CN.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>限制</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>用户类型</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>来宾</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>成员</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Resources/Strings.zh-TW.resx
+++ b/Source/CompanyCommunicator.Common/Resources/Strings.zh-TW.resx
@@ -247,4 +247,13 @@
   <data name="Throttled" xml:space="preserve">
     <value>已節流</value>
   </data>
+  <data name="ColumnName_UserType" xml:space="preserve">
+    <value>使用者類型</value>
+  </data>
+  <data name="Guest" xml:space="preserve">
+    <value>來賓</value>
+  </data>
+  <data name="Member" xml:space="preserve">
+    <value>成員</value>
+  </data>
 </root>

--- a/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/TeamWork/AppManagerService.cs
+++ b/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/TeamWork/AppManagerService.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
     using System.Threading.Tasks;
 
     using Microsoft.Graph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
 
     /// <summary>
     /// Manage Teams Apps for a user or a team.
@@ -52,8 +53,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
 
             // Skip Guest users.
             var user = await this.graphServiceClient.Users[userId].Request().GetAsync();
-            if (!string.Equals(user.UserType, "Guest", StringComparison.OrdinalIgnoreCase)
-                && !user.UserPrincipalName.ToLower().Contains("#ext#"))
+            if (string.Equals(user?.UserType, UserType.Member, StringComparison.OrdinalIgnoreCase))
             {
                 await this.graphServiceClient.Users[userId]
                 .Teamwork

--- a/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/UserType.cs
+++ b/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/UserType.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="UserType.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph
+{
+    /// <summary>
+    /// This represents the User Type property of User entity in Microsoft Graph.
+    /// Ref : https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0.
+    /// The values should be kept exactly the same to the values of userType property.
+    /// </summary>
+    public class UserType
+    {
+        /// <summary>
+        /// This represents Member value of userType property of User entity in Microsoft Graph.
+        /// </summary>
+        public const string Member = "Member";
+
+        /// <summary>
+        /// This represents Guest value of userType property of User entity in Microsoft Graph.
+        /// </summary>
+        public const string Guest = "Guest";
+    }
+}

--- a/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/Users/UsersService.cs
+++ b/Source/CompanyCommunicator.Common/Services/MicrosoftGraph/Users/UsersService.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
                 }
 
                 var filterUserIds = this.GetUserIdFilter(userIds);
-                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/users?$filter={filterUserIds}&$select=id,displayName,userPrincipalName");
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, $"https://graph.microsoft.com/v1.0/users?$filter={filterUserIds}&$select=id,displayName,userPrincipalName,userType");
                 batchRequestContent.AddBatchRequestStep(new BatchRequestStep(requestId.ToString(), httpRequestMessage));
 
                 if (batchRequestContent.BatchRequestSteps.Count() % maxNoBatchItems == 0)

--- a/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
+++ b/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Integration.AspNet.Core;
     using Microsoft.Bot.Builder.Teams;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
     using Microsoft.Extensions.Options;
-    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Adapter;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Extensions;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.CommonBot;
@@ -25,7 +25,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
     /// </summary>
     public class TeamMembersService : ITeamMembersService
     {
-        private readonly ICCBotFrameworkHttpAdapter botAdapter;
+        private readonly BotFrameworkHttpAdapter botAdapter;
         private readonly string userAppId;
         private readonly string authorAppId;
 
@@ -35,7 +35,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
         /// <param name="botAdapter">Bot adapter.</param>
         /// <param name="botOptions">Bot options.</param>
         public TeamMembersService(
-            ICCBotFrameworkHttpAdapter botAdapter,
+            BotFrameworkHttpAdapter botAdapter,
             IOptions<BotOptions> botOptions)
         {
             this.botAdapter = botAdapter ?? throw new ArgumentNullException(nameof(botAdapter));

--- a/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
+++ b/Source/CompanyCommunicator.Common/Services/Teams/TeamMembers/TeamMembersService.cs
@@ -11,11 +11,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
     using Microsoft.Bot.Builder.Teams;
     using Microsoft.Bot.Schema;
     using Microsoft.Bot.Schema.Teams;
     using Microsoft.Extensions.Options;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Adapter;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Extensions;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.CommonBot;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
     /// </summary>
     public class TeamMembersService : ITeamMembersService
     {
-        private readonly BotFrameworkHttpAdapter botAdapter;
+        private readonly ICCBotFrameworkHttpAdapter botAdapter;
         private readonly string userAppId;
         private readonly string authorAppId;
 
@@ -34,7 +35,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
         /// <param name="botAdapter">Bot adapter.</param>
         /// <param name="botOptions">Bot options.</param>
         public TeamMembersService(
-            BotFrameworkHttpAdapter botAdapter,
+            ICCBotFrameworkHttpAdapter botAdapter,
             IOptions<BotOptions> botOptions)
         {
             this.botAdapter = botAdapter ?? throw new ArgumentNullException(nameof(botAdapter));
@@ -86,6 +87,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
                             ServiceUrl = serviceUrl,
                             AadId = member.AadObjectId,
                             TenantId = tenantId,
+                            UserType = member.UserPrincipalName.GetUserType(),
                         };
 
                         return userDataEntity;
@@ -119,10 +121,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams
                     continuationToken,
                     cancellationToken);
                 continuationToken = currentPage.ContinuationToken;
-
-                // Skip Guest users.
-                var membersWithoutGuests = currentPage.Members.Where(member => !member.UserPrincipalName.ToLower().Contains("#ext#"));
-                members.AddRange(membersWithoutGuests);
+                members.AddRange(currentPage.Members);
             }
             while (continuationToken != null && !cancellationToken.IsCancellationRequested);
 

--- a/Source/CompanyCommunicator.Common/Services/User/IUserTypeService.cs
+++ b/Source/CompanyCommunicator.Common/Services/User/IUserTypeService.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="IUserTypeService.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
+
+    /// <summary>
+    /// The user type service interface.
+    /// </summary>
+    public interface IUserTypeService
+    {
+        /// <summary>
+        /// Update user type of existing user if it is not set.
+        /// </summary>
+        /// <param name="userDataEntity">User Data Entity.</param>
+        /// <param name="userType">Type of the user such as Member or Guest.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        public Task UpdateUserTypeForExistingUserAsync(UserDataEntity userDataEntity, string userType);
+
+        /// <summary>
+        /// Update user type of existing user list if it is not set.
+        /// </summary>
+        /// <param name="userDataEntities">User Data Entity list.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        public Task UpdateUserTypeForExistingUserListAsync(IEnumerable<UserDataEntity> userDataEntities);
+    }
+}

--- a/Source/CompanyCommunicator.Common/Services/User/UserDataService.cs
+++ b/Source/CompanyCommunicator.Common/Services/User/UserDataService.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User
     using System.Threading.Tasks;
     using Microsoft.Bot.Schema;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
 
     /// <summary>
     /// User Data service.
@@ -91,6 +92,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User
                 ConversationId = partitionKey.Equals(UserDataTableNames.UserDataPartition) ? activity?.Conversation?.Id : null,
                 ServiceUrl = activity?.ServiceUrl,
                 TenantId = activity?.Conversation?.TenantId,
+
+                // Setting this userType value as Member, since the guest userType is skipped.
+                UserType = UserType.Member,
             };
         }
     }

--- a/Source/CompanyCommunicator.Common/Services/User/UserTypeService.cs
+++ b/Source/CompanyCommunicator.Common/Services/User/UserTypeService.cs
@@ -1,0 +1,106 @@
+﻿// <copyright file="UserTypeService.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Graph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Extensions;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+
+    /// <summary>
+    /// This service is to set user type for existing users.
+    /// </summary>
+    public class UserTypeService : IUserTypeService
+    {
+        private readonly IUserDataRepository userDataRepository;
+        private readonly IUsersService usersService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserTypeService"/> class.
+        /// </summary>
+        /// <param name="userDataRepository">User data repository.</param>
+        /// <param name="usersService">Users service.</param>
+        public UserTypeService(
+            IUserDataRepository userDataRepository,
+            IUsersService usersService)
+        {
+            this.userDataRepository = userDataRepository ?? throw new ArgumentNullException(nameof(userDataRepository));
+            this.usersService = usersService ?? throw new ArgumentNullException(nameof(usersService));
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateUserTypeForExistingUserAsync(UserDataEntity userDataEntity, string userType)
+        {
+            if (userDataEntity == null)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(userDataEntity.UserType))
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(userType))
+            {
+                throw new ArgumentNullException(nameof(userType));
+            }
+
+            userDataEntity.UserType = userType;
+            await this.userDataRepository.InsertOrMergeAsync(userDataEntity);
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateUserTypeForExistingUserListAsync(IEnumerable<UserDataEntity> userDataEntities)
+        {
+            if (userDataEntities.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            var userDataEntitiesWithNoUserType = userDataEntities.Where(userDataEntities => string.IsNullOrEmpty(userDataEntities.UserType));
+
+            if (userDataEntitiesWithNoUserType.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            var users = await this.usersService.GetBatchByUserIds(
+                      userDataEntitiesWithNoUserType
+                      .Select(user => user.AadId)
+                      .ToList()
+                      .AsGroups());
+
+            if (!users.IsNullOrEmpty())
+            {
+                var maxParallelism = Math.Min(users.Count(), 30);
+                await users.ForEachAsync(maxParallelism, this.UpdateUserTypeAsync);
+            }
+        }
+
+        private async Task UpdateUserTypeAsync(User user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            // Store user.
+            await this.userDataRepository.InsertOrMergeAsync(
+                new UserDataEntity()
+                {
+                    PartitionKey = UserDataTableNames.UserDataPartition,
+                    RowKey = user.Id,
+                    AadId = user.Id,
+                    UserType = user.UserType,
+                });
+        }
+    }
+}

--- a/Source/CompanyCommunicator.Prep.Func/Export/Mappers/UserDataMap.cs
+++ b/Source/CompanyCommunicator.Prep.Func/Export/Mappers/UserDataMap.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Mappers
             this.Map(x => x.Id).Name(this.localizer.GetString("ColumnName_UserId"));
             this.Map(x => x.Upn).Name(this.localizer.GetString("ColumnName_Upn"));
             this.Map(x => x.Name).Name(this.localizer.GetString("ColumnName_UserName"));
+            this.Map(x => x.UserType).Name(this.localizer.GetString("ColumnName_UserType"));
             this.Map(x => x.DeliveryStatus).Name(this.localizer.GetString("ColumnName_DeliveryStatus"));
             this.Map(x => x.StatusReason).Name(this.localizer.GetString("ColumnName_StatusReason"));
         }

--- a/Source/CompanyCommunicator.Prep.Func/Export/Model/UserData.cs
+++ b/Source/CompanyCommunicator.Prep.Func/Export/Model/UserData.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Model
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the user type.
+        /// </summary>
+        public string UserType { get; set; }
+
+        /// <summary>
         /// Gets or sets the delivery status value.
         /// </summary>
         public string DeliveryStatus { get; set; }

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncAllUsersActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncAllUsersActivity.cs
@@ -8,10 +8,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.DurableTask;
     using Microsoft.Extensions.Localization;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Graph;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Extensions;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.NotificationData;
@@ -19,6 +21,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend.Extensions;
 
     /// <summary>
@@ -30,6 +33,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         private readonly ISentNotificationDataRepository sentNotificationDataRepository;
         private readonly IUsersService usersService;
         private readonly INotificationDataRepository notificationDataRepository;
+        private readonly IUserTypeService userTypeService;
         private readonly IStringLocalizer<Strings> localizer;
 
         /// <summary>
@@ -39,18 +43,21 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// <param name="sentNotificationDataRepository">Sent notification data repository.</param>
         /// <param name="usersService">Users service.</param>
         /// <param name="notificationDataRepository">Notification data entity repository.</param>
+        /// <param name="userTypeService">User type service.</param>
         /// <param name="localizer">Localization service.</param>
         public SyncAllUsersActivity(
             IUserDataRepository userDataRepository,
             ISentNotificationDataRepository sentNotificationDataRepository,
             IUsersService usersService,
             INotificationDataRepository notificationDataRepository,
+            IUserTypeService userTypeService,
             IStringLocalizer<Strings> localizer)
         {
             this.userDataRepository = userDataRepository ?? throw new ArgumentNullException(nameof(userDataRepository));
             this.sentNotificationDataRepository = sentNotificationDataRepository ?? throw new ArgumentNullException(nameof(sentNotificationDataRepository));
             this.usersService = usersService ?? throw new ArgumentNullException(nameof(usersService));
             this.notificationDataRepository = notificationDataRepository ?? throw new ArgumentNullException(nameof(notificationDataRepository));
+            this.userTypeService = userTypeService ?? throw new ArgumentNullException(nameof(userTypeService));
             this.localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
         }
 
@@ -58,9 +65,10 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// Syncs all users to Sent notification table.
         /// </summary>
         /// <param name="notification">Notification.</param>
+        /// <param name="log">Logging service.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [FunctionName(FunctionNames.SyncAllUsersActivity)]
-        public async Task RunAsync([ActivityTrigger] NotificationDataEntity notification)
+        public async Task RunAsync([ActivityTrigger] NotificationDataEntity notification, ILogger log)
         {
             if (notification == null)
             {
@@ -73,10 +81,20 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             // Get users.
             var users = await this.userDataRepository.GetAllAsync();
 
-            // Store in sent notification table.
-            var recipients = users.Select(
-                user => user.CreateInitialSentNotificationDataEntity(partitionKey: notification.Id));
-            await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+            // This is to set user type.
+            await this.userTypeService.UpdateUserTypeForExistingUserListAsync(users);
+            users = await this.userDataRepository.GetAllAsync();
+
+            // Filter for only Members.
+            users = users?.Where(user => user.UserType.Equals(UserType.Member, StringComparison.OrdinalIgnoreCase));
+
+            if (!users.IsNullOrEmpty())
+            {
+                // Store in sent notification table.
+                var recipients = users.Select(
+                    user => user.CreateInitialSentNotificationDataEntity(partitionKey: notification.Id));
+                await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+            }
         }
 
         /// <summary>
@@ -90,13 +108,13 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             (IEnumerable<User>, string) tuple = (new List<User>(), string.Empty);
             try
             {
-                tuple = await this.usersService.GetAllUsersAsync(deltaLink);
+                tuple = await this.GetAllUsers(notificationId, deltaLink);
             }
-            catch (ServiceException exception)
+            catch (InvalidOperationException)
             {
-                var errorMessage = this.localizer.GetString("FailedToGetAllUsersFormat", exception.StatusCode, exception.Message);
-                await this.notificationDataRepository.SaveWarningInNotificationDataEntityAsync(notificationId, errorMessage);
-                return;
+                // If delta link is expired, this exception is caught.
+                // re-sync users wthout delta link.
+                tuple = await this.GetAllUsers(notificationId);
             }
 
             // process users.
@@ -111,6 +129,28 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             if (!string.IsNullOrEmpty(tuple.Item2))
             {
                 await this.userDataRepository.SetDeltaLinkAsync(tuple.Item2);
+            }
+        }
+
+        private async Task<(IEnumerable<User>, string)> GetAllUsers(string notificationId, string deltaLink = null)
+        {
+            try
+            {
+                return await this.usersService.GetAllUsersAsync(deltaLink);
+            }
+            catch (ServiceException serviceException)
+            {
+                if (serviceException.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    // this case is to handle expired delta link.
+                    throw new InvalidOperationException();
+                }
+                else
+                {
+                    var errorMessage = this.localizer.GetString("FailedToGetAllUsersFormat", serviceException.StatusCode, serviceException.Message);
+                    await this.notificationDataRepository.SaveWarningInNotificationDataEntityAsync(notificationId, errorMessage);
+                    throw serviceException;
+                }
             }
         }
 
@@ -129,7 +169,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             }
 
             // skip Guest users.
-            if (string.Equals(user.UserType, "Guest", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(user.UserType, UserType.Guest, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -156,6 +196,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
                     PartitionKey = UserDataTableNames.UserDataPartition,
                     RowKey = user.Id,
                     AadId = user.Id,
+                    UserType = user.UserType,
                 });
         }
     }

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncGroupMembersActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncGroupMembersActivity.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend.Extensions;
 
     /// <summary>
@@ -32,6 +33,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         private readonly INotificationDataRepository notificationDataRepository;
         private readonly ISentNotificationDataRepository sentNotificationDataRepository;
         private readonly IUserDataRepository userDataRepository;
+        private readonly IUserTypeService userTypeService;
         private readonly IStringLocalizer<Strings> localizer;
 
         /// <summary>
@@ -41,18 +43,21 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// <param name="notificationDataRepository">Notifications data repository.</param>
         /// <param name="groupMembersService">Group members service.</param>
         /// <param name="userDataRepository">User Data repository.</param>
+        /// <param name="userTypeService">User Type service.</param>
         /// <param name="localizer">Localization service.</param>
         public SyncGroupMembersActivity(
             ISentNotificationDataRepository sentNotificationDataRepository,
             INotificationDataRepository notificationDataRepository,
             IGroupMembersService groupMembersService,
             IUserDataRepository userDataRepository,
+            IUserTypeService userTypeService,
             IStringLocalizer<Strings> localizer)
         {
             this.groupMembersService = groupMembersService ?? throw new ArgumentNullException(nameof(groupMembersService));
             this.notificationDataRepository = notificationDataRepository ?? throw new ArgumentNullException(nameof(notificationDataRepository));
             this.sentNotificationDataRepository = sentNotificationDataRepository ?? throw new ArgumentNullException(nameof(sentNotificationDataRepository));
             this.userDataRepository = userDataRepository ?? throw new ArgumentNullException(nameof(userDataRepository));
+            this.userTypeService = userTypeService ?? throw new ArgumentNullException(nameof(userTypeService));
             this.localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
         }
 
@@ -92,8 +97,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
                 // Convert to Recipients
                 var recipients = await this.GetRecipientsAsync(notificationId, users);
 
-                // Store.
-                await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+                if (!recipients.IsNullOrEmpty())
+                {
+                    // Store.
+                    await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+                }
             }
             catch (Exception ex)
             {
@@ -117,10 +125,13 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             var maxParallelism = Math.Min(100, users.Count());
             await Task.WhenAll(users.ForEachAsync(maxParallelism, async user =>
             {
-                // Skip Guest users.
-                if (!user.UserPrincipalName.ToLower().Contains("#ext#"))
+                var userEntity = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.Id);
+
+                // This is to set the type of user(exisiting only, new ones will be skipped) to identify later if it is member or guest.
+                var userType = user.UserPrincipalName.GetUserType();
+                await this.userTypeService.UpdateUserTypeForExistingUserAsync(userEntity, userType);
+                if (userType.Equals(UserType.Member, StringComparison.OrdinalIgnoreCase))
                 {
-                    var userEntity = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.Id);
                     if (userEntity == null)
                     {
                         userEntity = new UserDataEntity()

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncTeamMembersActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/SyncTeamMembersActivity.cs
@@ -20,7 +20,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.TeamData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend.Extensions;
 
     /// <summary>
@@ -34,6 +36,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         private readonly ISentNotificationDataRepository sentNotificationDataRepository;
         private readonly IStringLocalizer<Strings> localizer;
         private readonly IUserDataRepository userDataRepository;
+        private readonly IUserTypeService userTypeService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SyncTeamMembersActivity"/> class.
@@ -44,13 +47,15 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
         /// <param name="sentNotificationDataRepository">Sent notification data repository.</param>
         /// <param name="localizer">Localization service.</param>
         /// <param name="userDataRepository">User Data repository.</param>
+        /// <param name="userTypeService">User Type service.</param>
         public SyncTeamMembersActivity(
             ITeamDataRepository teamDataRepository,
             ITeamMembersService memberService,
             INotificationDataRepository notificationDataRepository,
             ISentNotificationDataRepository sentNotificationDataRepository,
             IStringLocalizer<Strings> localizer,
-            IUserDataRepository userDataRepository)
+            IUserDataRepository userDataRepository,
+            IUserTypeService userTypeService)
         {
             this.teamDataRepository = teamDataRepository ?? throw new ArgumentNullException(nameof(teamDataRepository));
             this.memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
@@ -58,6 +63,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             this.sentNotificationDataRepository = sentNotificationDataRepository ?? throw new ArgumentNullException(nameof(sentNotificationDataRepository));
             this.localizer = localizer ?? throw new ArgumentNullException(nameof(localizer));
             this.userDataRepository = userDataRepository ?? throw new ArgumentNullException(nameof(userDataRepository));
+            this.userTypeService = userTypeService ?? throw new ArgumentNullException(nameof(userTypeService));
         }
 
         /// <summary>
@@ -110,8 +116,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
                 // Convert to Recipients.
                 var recipients = await this.GetRecipientsAsync(notificationId, userEntities);
 
-                // Store.
-                await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+                if (!recipients.IsNullOrEmpty())
+                {
+                    // Store.
+                    await this.sentNotificationDataRepository.BatchInsertOrMergeAsync(recipients);
+                }
             }
             catch (Exception ex)
             {
@@ -136,8 +145,14 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
             await Task.WhenAll(users.ForEachAsync(maxParallelism, async user =>
             {
                 var userEntity = await this.userDataRepository.GetAsync(UserDataTableNames.UserDataPartition, user.AadId);
-                user.ConversationId ??= userEntity?.ConversationId;
-                recipients.Add(user.CreateInitialSentNotificationDataEntity(partitionKey: notificationId));
+
+                // This is to set the type of user(exisiting only, new ones will be skipped) to identify later if it is member or guest.
+                await this.userTypeService.UpdateUserTypeForExistingUserAsync(userEntity, user.UserType);
+                if (user.UserType.Equals(UserType.Member, StringComparison.OrdinalIgnoreCase))
+                {
+                    user.ConversationId ??= userEntity?.ConversationId;
+                    recipients.Add(user.CreateInitialSentNotificationDataEntity(partitionKey: notificationId));
+                }
             }));
 
             return recipients;

--- a/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/TeamsConversationActivity.cs
+++ b/Source/CompanyCommunicator.Prep.Func/PreparingToSend/Activities/TeamsConversationActivity.cs
@@ -253,6 +253,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend
                 ConversationId = recipient.ConversationId,
                 ServiceUrl = recipient.ServiceUrl,
                 TenantId = recipient.TenantId,
+
+                // Setting the userType value as Member,
+                // since only Member type users is allowed to be stored in Sent Notification Table.
+                // Existing or new Guest users is skipped from recipient list.
+                UserType = UserType.Member,
             };
 
             await this.userDataRepository.InsertOrMergeAsync(user);

--- a/Source/CompanyCommunicator.Prep.Func/Startup.cs
+++ b/Source/CompanyCommunicator.Prep.Func/Startup.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MessageQueues.SendQueue;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Export.Streams;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend;
 
@@ -127,6 +128,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func
             builder.Services.AddTransient<AdaptiveCardCreator>();
             builder.Services.AddTransient<IAppSettingsService, AppSettingsService>();
             builder.Services.AddTransient<IStorageClientFactory, StorageClientFactory>();
+            builder.Services.AddTransient<IUserTypeService, UserTypeService>();
 
             // Add Teams services.
             builder.Services.AddTransient<ITeamMembersService, TeamMembersService>();

--- a/Source/CompanyCommunicator/ClientApp/package-lock.json
+++ b/Source/CompanyCommunicator/ClientApp/package-lock.json
@@ -1282,6 +1282,11 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -6497,6 +6502,11 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -8156,9 +8166,9 @@
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -10887,9 +10897,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -13276,6 +13286,13 @@
       "requires": {
         "lodash": "^4.17.20",
         "renderkid": "^2.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
       }
     },
     "pretty-format": {
@@ -13565,9 +13582,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
-      "integrity": "sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.3.tgz",
+      "integrity": "sha512-4lEA5gF4OHrcJLMUV1t+4XbNDiJbsAWCH5Z2uqlTqW6dD7Cf5nEASkeXrCI/Mz83sI2o527oBIFKVMXtRf1Vtg==",
       "requires": {
         "@babel/code-frame": "7.10.4",
         "address": "1.1.2",
@@ -14189,6 +14206,11 @@
             "domelementtype": "^2.2.0",
             "domhandler": "^4.2.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "nth-check": {
           "version": "2.0.0",
@@ -15789,6 +15811,11 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },

--- a/Source/Test/CompanyCommunicator.Common.Test/Services/MicrosoftGraph/UserTypeServiceTest.cs
+++ b/Source/Test/CompanyCommunicator.Common.Test/Services/MicrosoftGraph/UserTypeServiceTest.cs
@@ -1,0 +1,289 @@
+﻿// <copyright file="UserTypeServiceTest.cs" company="Microsoft">
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// </copyright>
+
+namespace Microsoft.Teams.App.CompanyCommunicator.Common.Test.Services.MicrosoftGraph
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Graph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// User Type service test.
+    /// </summary>
+    public class UserTypeServiceTest
+    {
+        private readonly Mock<IUsersService> usersService = new Mock<IUsersService>();
+        private readonly Mock<IUserDataRepository> userRespositoryService = new Mock<IUserDataRepository>();
+
+        /// <summary>
+        /// Test case to check if ArgumentNullException is thrown if parameters are null.
+        /// </summary>
+        [Fact]
+        public void UserTypeService_NullParameters_ShouldThrowException()
+        {
+            Action action1 = () => new UserTypeService(null, this.usersService.Object);
+            Action action2 = () => new UserTypeService(this.userRespositoryService.Object, null);
+            Action action3 = () => new UserTypeService(this.userRespositoryService.Object, this.usersService.Object);
+
+            action1.Should().Throw<ArgumentNullException>();
+            action2.Should().Throw<ArgumentNullException>();
+            action3.Should().NotThrow();
+        }
+
+        /// <summary>
+        /// Test case to verify that no action is taken when user data is null.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NullUserData_ShouldNotSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserAsync(null, null);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that exception is thrown when user type parameter is null.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NullUserType_ShouldThrowException()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            var userData = new UserDataEntity() { AadId = "userId", UserType = null };
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserAsync(userData, null);
+
+            // Assert
+            await task.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        /// <summary>
+        /// Test case to verify that no action is taken when user data has user type assigned.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_ExistingUserType_ShouldNotSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            var userData = new UserDataEntity() { AadId = "userId", UserType = UserType.Member };
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserAsync(userData, null);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to check that if data is saved when the parameters is correct.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_CorrectParameters_ShouldSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            var userData = new UserDataEntity() { AadId = "userId", UserType = null };
+            var userType = UserType.Member;
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserAsync(userData, userType);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.Is<UserDataEntity>(x => x.UserType.Equals(userType))), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to check that no action is taken when there is null user data entities.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NullParameters_ShouldNotSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = null;
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that no data is saved when all users have user type assigned.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_UserTypeAssigned_ShouldNotSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { AadId = "1", UserType = UserType.Member },
+                new UserDataEntity() { AadId = "2", UserType = UserType.Member },
+            };
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that data is saved when there is no assignment for some user type.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_SomeUserTypeAssigned_ShouldSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { AadId = "1", UserType = UserType.Member },
+                new UserDataEntity() { AadId = "2", UserType = null },
+            };
+            var users = new List<User>()
+            {
+                new User() { Id = "2", UserType = UserType.Member },
+            };
+
+            this.usersService
+                .Setup(x => x.GetBatchByUserIds(It.IsAny<IEnumerable<IEnumerable<string>>>()))
+                .ReturnsAsync(users);
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.Is<UserDataEntity>(x => this.Compare(x, users.FirstOrDefault()))), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that data is saved when there is no user type.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NoUserTypeAssigned_ShouldSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { AadId = "1", UserType = null },
+            };
+            var users = new List<User>()
+            {
+                new User() { Id = "1", UserType = UserType.Member },
+            };
+
+            this.usersService
+                .Setup(x => x.GetBatchByUserIds(It.IsAny<IEnumerable<IEnumerable<string>>>()))
+                .ReturnsAsync(users);
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.Is<UserDataEntity>(x => this.Compare(x, users.FirstOrDefault()))), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that no action is taken on null data response from graph.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NullResponseFromGraph_ShouldNotSaveData()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { AadId = "1", UserType = null },
+            };
+            IEnumerable<User> users = null;
+
+            this.usersService
+                .Setup(x => x.GetBatchByUserIds(It.IsAny<IEnumerable<IEnumerable<string>>>()))
+                .ReturnsAsync(users);
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that exception is thrown when user is null in the response from graph.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task UserTypeService_NullResponseInUserListFromGraph_ShouldThrowException()
+        {
+            // Arrange
+            var serviceContext = this.GetUserTypeService();
+            IEnumerable<UserDataEntity> userDataEntities = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { AadId = "1", UserType = null },
+            };
+            IEnumerable<User> users = new List<User>()
+            { null };
+
+            this.usersService
+                .Setup(x => x.GetBatchByUserIds(It.IsAny<IEnumerable<IEnumerable<string>>>()))
+                .ReturnsAsync(users);
+
+            // Act
+            Func<Task> task = async () => await serviceContext.UpdateUserTypeForExistingUserListAsync(userDataEntities);
+
+            // Assert
+            await task.Should().ThrowAsync<ArgumentNullException>();
+            this.userRespositoryService.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+        }
+
+        private bool Compare(UserDataEntity userDataEntity, User user)
+        {
+            return userDataEntity.PartitionKey.Equals(UserDataTableNames.UserDataPartition)
+                && userDataEntity.RowKey.Equals(user.Id)
+                && userDataEntity.AadId.Equals(user.Id)
+                && userDataEntity.UserType.Equals(user.UserType);
+        }
+
+        private UserTypeService GetUserTypeService()
+        {
+            return new UserTypeService(this.userRespositoryService.Object, this.usersService.Object);
+        }
+    }
+}

--- a/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncAllUsersActivityTest.cs
+++ b/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncAllUsersActivityTest.cs
@@ -8,15 +8,18 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Net;
     using System.Threading.Tasks;
     using FluentAssertions;
     using Microsoft.Extensions.Localization;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Graph;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.NotificationData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.SentNotificationData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend;
     using Moq;
     using Xunit;
@@ -27,10 +30,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
     public class SyncAllUsersActivityTest
     {
         private readonly Mock<IUsersService> userService = new Mock<IUsersService>();
-        private readonly Mock<IStringLocalizer<Strings>> localier = new Mock<IStringLocalizer<Strings>>();
+        private readonly Mock<IStringLocalizer<Strings>> localizer = new Mock<IStringLocalizer<Strings>>();
         private readonly Mock<IUserDataRepository> userDataRepository = new Mock<IUserDataRepository>();
         private readonly Mock<ISentNotificationDataRepository> sentNotificationDataRepository = new Mock<ISentNotificationDataRepository>();
         private readonly Mock<INotificationDataRepository> notificationDataRepository = new Mock<INotificationDataRepository>();
+        private readonly Mock<IUserTypeService> userTypeService = new Mock<IUserTypeService>();
+        private readonly Mock<ILogger> logger = new Mock<ILogger>();
 
         /// <summary>
         /// Constructor tests.
@@ -39,41 +44,44 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         public void SyncAllUsersActivityConstructorTest()
         {
             // Arrange
-            Action action1 = () => new SyncAllUsersActivity(null /*userDataRepository*/, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.localier.Object);
-            Action action2 = () => new SyncAllUsersActivity(this.userDataRepository.Object, null /*sentNotificationDataRepository*/, this.userService.Object, this.notificationDataRepository.Object, this.localier.Object);
-            Action action3 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, null /*userService*/, this.notificationDataRepository.Object, this.localier.Object);
-            Action action4 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, null /*notificationDataRepository*/, this.localier.Object);
-            Action action5 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, null /*localier*/);
-            Action action6 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.localier.Object);
+            Action action1 = () => new SyncAllUsersActivity(null /*userDataRepository*/, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.userTypeService.Object, this.localizer.Object);
+            Action action2 = () => new SyncAllUsersActivity(this.userDataRepository.Object, null /*sentNotificationDataRepository*/, this.userService.Object, this.notificationDataRepository.Object, this.userTypeService.Object, this.localizer.Object);
+            Action action3 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, null /*userService*/, this.notificationDataRepository.Object, this.userTypeService.Object, this.localizer.Object);
+            Action action4 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, null /*notificationDataRepository*/, this.userTypeService.Object, this.localizer.Object);
+            Action action5 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, null /*userTypeService*/, this.localizer.Object);
+            Action action6 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.userTypeService.Object, null /*localizer*/);
+            Action action7 = () => new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.userTypeService.Object, this.localizer.Object);
 
             // Act and Assert.
             action1.Should().Throw<ArgumentNullException>("userDataRepository is null.");
             action2.Should().Throw<ArgumentNullException>("sentNotificationDataRepository is null.");
             action3.Should().Throw<ArgumentNullException>("userService is null.");
             action4.Should().Throw<ArgumentNullException>("notificationDataRepository is null.");
-            action5.Should().Throw<ArgumentNullException>("localier is null.");
-            action6.Should().NotThrow();
+            action5.Should().Throw<ArgumentNullException>("userTypeService is null.");
+            action6.Should().Throw<ArgumentNullException>("localizer is null.");
+            action7.Should().NotThrow();
         }
 
         /// <summary>
-        /// Success test for sync all user to repository.
+        /// Test case to verify all member type users gets stored in sentNotification table.
         /// </summary>
         /// <returns>A task that represents the work queued to execute.</returns>
         [Fact]
-        public async Task SyncAllUsersActivitySuccessTest()
+        public async Task SyncAllUsers_OnlyMemberTypeUsers_ShouldBeSavedInSentNotificationTable()
         {
             // Arrange
             var activityContext = this.GetSyncAllUsersActivity();
             string deltaLink = "deltaLink";
-            IEnumerable<UserDataEntity> useDataResponse = new List<UserDataEntity>()
+            IEnumerable<UserDataEntity> userDataResponse = new List<UserDataEntity>()
             {
-               new UserDataEntity() { Name = string.Empty },
+               new UserDataEntity() { Name = "user1", UserType = UserType.Member },
+               new UserDataEntity() { Name = "user2", UserType = UserType.Member },
             };
             NotificationDataEntity notification = new NotificationDataEntity()
             {
                 Id = "notificationId1",
             };
-            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "100" } }, deltaLink);
+            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "101", UserType = UserType.Member } }, deltaLink);
             this.userDataRepository
                 .Setup(x => x.GetDeltaLinkAsync())
                 .ReturnsAsync(deltaLink);
@@ -86,10 +94,13 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
                 .Returns(Task.CompletedTask);
             this.userDataRepository
                 .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
-                .ReturnsAsync(useDataResponse);
+                .ReturnsAsync(userDataResponse);
             this.userService
                 .Setup(x => x.HasTeamsLicenseAsync(It.IsAny<string>()))
                 .ReturnsAsync(true);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserListAsync(It.IsAny<IEnumerable<UserDataEntity>>()))
+                .Returns(Task.CompletedTask);
 
             // store user data
             this.userDataRepository
@@ -98,26 +109,321 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
             this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
 
             // Act
-            Func<Task> task = async () => await activityContext.RunAsync(notification);
+            Func<Task> task = async () => await activityContext.RunAsync(notification, this.logger.Object);
 
             // Assert
             await task.Should().NotThrowAsync();
             this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.Is<UserDataEntity>(x => x.RowKey == tuple.Item1.FirstOrDefault().Id)));
-            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 2)), Times.Once);
         }
 
         /// <summary>
-        /// ArgumentNullException test for notification null.
+        /// Test case to verify guest users from Graph service does not get saved in UserData table.
         /// </summary>
         /// <returns>A task that represents the work queued to execute.</returns>
         [Fact]
-        public async Task ArgumentNullExceptionTest()
+        public async Task SyncAllUsers_GuestUsersFromGraph_ShouldNotBeSavedInTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            string deltaLink = "deltaLink";
+            IEnumerable<UserDataEntity> userDataResponse = new List<UserDataEntity>()
+            {
+               new UserDataEntity() { Name = "user1", UserType = UserType.Member },
+               new UserDataEntity() { Name = "user2", UserType = UserType.Guest },
+            };
+            NotificationDataEntity notification = new NotificationDataEntity()
+            {
+                Id = "notificationId1",
+            };
+            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "101", UserType = "Guest" } }, deltaLink);
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(deltaLink);
+            this.userService
+                .Setup(x => x.GetAllUsersAsync(It.IsAny<string>()))
+                .ReturnsAsync(tuple);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userDataResponse);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserListAsync(It.IsAny<IEnumerable<UserDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // store user data
+            this.userDataRepository
+                .Setup(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+            this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 1)), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify both guest users from Graph and existing guest users gets filtered and not stored in sentNotificatinData table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUsers_AllGuestUsers_ShouldNeverBeSavedInTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            string deltaLink = "deltaLink";
+            IEnumerable<UserDataEntity> userDataResponse = new List<UserDataEntity>()
+            {
+               new UserDataEntity() { Name = string.Empty, UserType = UserType.Guest },
+               new UserDataEntity() { Name = string.Empty, UserType = UserType.Guest },
+            };
+            NotificationDataEntity notification = new NotificationDataEntity()
+            {
+                Id = "notificationId1",
+            };
+            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "101", UserType = "Guest" } }, deltaLink);
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(deltaLink);
+            this.userService
+                .Setup(x => x.GetAllUsersAsync(It.IsAny<string>()))
+                .ReturnsAsync(tuple);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userDataResponse);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserListAsync(It.IsAny<IEnumerable<UserDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // store user data
+            this.userDataRepository
+                .Setup(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+            this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+
+            // Act
+            await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that no exception is thrown when there is no users in db.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUsers_NullUsersFromDB_ShouldNotThrowException()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            string deltaLink = "deltaLink";
+            IEnumerable<UserDataEntity> userDataResponse = null;
+            NotificationDataEntity notification = new NotificationDataEntity()
+            {
+                Id = "notificationId1",
+            };
+            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "101", UserType = "Guest" } }, deltaLink);
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(deltaLink);
+            this.userService
+                .Setup(x => x.GetAllUsersAsync(It.IsAny<string>()))
+                .ReturnsAsync(tuple);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userDataResponse);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserListAsync(It.IsAny<IEnumerable<UserDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // store user data
+            this.userDataRepository
+                .Setup(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+            this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+
+            // Act
+            await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify when deltalink is expired InvalidaOperationException is thrown to call SyncAllUsers again.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUsers_ExpiredDeltaLink_ThrowsInvalidOperationException()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            string deltaLink = "expiredDeltaLink";
+            IEnumerable<UserDataEntity> userDataResponse = new List<UserDataEntity>()
+            {
+               new UserDataEntity() { Name = string.Empty },
+            };
+            NotificationDataEntity notification = new NotificationDataEntity()
+            {
+                Id = "notificationId1",
+            };
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(deltaLink);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userDataResponse);
+
+            var serviceException = new ServiceException(null, null, HttpStatusCode.BadRequest);
+            this.userService.Setup(x => x.GetAllUsersAsync(It.IsAny<string>())).ThrowsAsync(serviceException);
+
+            Func<Task> task = async () => await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            await task.Should().ThrowAsync<InvalidOperationException>();
+            this.userService.Verify(x => x.GetAllUsersAsync(It.IsAny<string>()), Times.Exactly(2));
+        }
+
+        /// <summary>
+        /// Test method to verify that removed users as per deltalink from graph
+        /// should be deleted from User table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUser_RemovedUsers_DeleteUserFromTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            string deltaLink = "deltaLink";
+            IEnumerable<UserDataEntity> userDataResponse = new List<UserDataEntity>()
+            {
+               new UserDataEntity() { Name = string.Empty, UserType = UserType.Member },
+            };
+            NotificationDataEntity notification = new NotificationDataEntity()
+            {
+                Id = "notificationId1",
+            };
+            var userData = new UserDataEntity() { AadId = "101" };
+
+            (IEnumerable<User>, string) tuple = (new List<User>() { new User() { Id = "101", AdditionalData = new Dictionary<string, object>() { { "@removed", null } } } }, deltaLink);
+
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(deltaLink);
+            this.userService
+                .Setup(x => x.GetAllUsersAsync(It.IsAny<string>()))
+                .ReturnsAsync(tuple);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userDataResponse);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.userDataRepository
+                .Setup(x => x.DeleteAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+
+            // store user data
+            this.userDataRepository
+                .Setup(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+            this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+
+            // Act
+            await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()), Times.Never);
+            this.userDataRepository.Verify(x => x.DeleteAsync(It.IsAny<UserDataEntity>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Test method to verify users with no team license will not get saved in UserData table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUsers_NoTeamsLicense_NeverGetSavedInTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncAllUsersActivity();
+            var userList = new List<UserDataEntity>()
+            {
+               new UserDataEntity() { Name = "user1", UserType = UserType.Guest },
+            };
+            var notification = new NotificationDataEntity() { Id = "notificationId1" };
+            var tuple = (new List<User>() { new User() { Id = "101" } }, string.Empty);
+
+            this.userDataRepository
+                .Setup(x => x.GetDeltaLinkAsync())
+                .ReturnsAsync(string.Empty);
+            this.userService
+                .Setup(x => x.GetAllUsersAsync(It.IsAny<string>()))
+                .ReturnsAsync(tuple);
+
+            this.userDataRepository
+                .Setup(x => x.SetDeltaLinkAsync(It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+            this.userDataRepository
+                .Setup(x => x.GetAllAsync(It.IsAny<string>(), null))
+                .ReturnsAsync(userList);
+
+            this.userService
+                .Setup(x => x.HasTeamsLicenseAsync(It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // store user data
+            this.userDataRepository
+                .Setup(x => x.InsertOrMergeAsync(It.IsAny<UserDataEntity>()))
+                .Returns(Task.CompletedTask);
+            this.sentNotificationDataRepository.Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()));
+
+            // Act
+            await activityContext.RunAsync(notification, this.logger.Object);
+
+            // Assert
+            this.userDataRepository.Verify(x => x.InsertOrMergeAsync(It.Is<UserDataEntity>(x => x.RowKey == tuple.Item1.FirstOrDefault().Id)), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to check ArgumentNullException when parameter is null.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncAllUsers_NullParameter_ShouldThrowException()
         {
             // Arrange
             var activityContext = this.GetSyncAllUsersActivity();
 
             // Act
-            Func<Task> task = async () => await activityContext.RunAsync(null /*notification*/);
+            Func<Task> task = async () => await activityContext.RunAsync(null /*notification*/, this.logger.Object);
 
             // Assert
             await task.Should().ThrowAsync<ArgumentNullException>("notification is null");
@@ -128,7 +434,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         /// </summary>
         private SyncAllUsersActivity GetSyncAllUsersActivity()
         {
-            return new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.localier.Object);
+            return new SyncAllUsersActivity(this.userDataRepository.Object, this.sentNotificationDataRepository.Object, this.userService.Object, this.notificationDataRepository.Object, this.userTypeService.Object, this.localizer.Object);
         }
     }
 }

--- a/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncGroupMembersActivityTest.cs
+++ b/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncGroupMembersActivityTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend;
     using Moq;
     using Xunit;
@@ -33,6 +34,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         private readonly Mock<IUserDataRepository> userDataRepository = new Mock<IUserDataRepository>();
         private readonly Mock<ISentNotificationDataRepository> sentNotificationDataRepository = new Mock<ISentNotificationDataRepository>();
         private readonly Mock<INotificationDataRepository> notificationDataRepository = new Mock<INotificationDataRepository>();
+        private readonly Mock<IUserTypeService> userTypeService = new Mock<IUserTypeService>();
 
         /// <summary>
         /// Constructor tests.
@@ -41,12 +43,13 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         public void ConstructorArgumentNullException_Test()
         {
             // Arrange
-            Action action1 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, null /*userDataRepository*/, this.localier.Object);
-            Action action2 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, null /*localier*/);
-            Action action3 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, null /*groupMembersService*/, this.userDataRepository.Object, this.localier.Object);
-            Action action4 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, null /*notificationDataRepository*/, this.groupMembersService.Object, this.userDataRepository.Object, this.localier.Object);
-            Action action5 = () => new SyncGroupMembersActivity(null /*sentNotificationDataRepository*/, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.localier.Object);
-            Action action6 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.localier.Object);
+            Action action1 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, null /*userDataRepository*/, this.userTypeService.Object, this.localier.Object);
+            Action action2 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.userTypeService.Object, null /*localier*/);
+            Action action3 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, null /*groupMembersService*/, this.userDataRepository.Object, this.userTypeService.Object, this.localier.Object);
+            Action action4 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, null /*notificationDataRepository*/, this.groupMembersService.Object, this.userDataRepository.Object, this.userTypeService.Object, this.localier.Object);
+            Action action5 = () => new SyncGroupMembersActivity(null /*sentNotificationDataRepository*/, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.userTypeService.Object, this.localier.Object);
+            Action action6 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.userTypeService.Object, this.localier.Object);
+            Action action7 = () => new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, null /*userTypeService*/, this.localier.Object);
 
             // Act and Assert.
             action1.Should().Throw<ArgumentNullException>("userDataRepository is null.");
@@ -55,14 +58,15 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
             action4.Should().Throw<ArgumentNullException>("notificationDataRepository is null.");
             action5.Should().Throw<ArgumentNullException>("sentNotificationDataRepository is null.");
             action6.Should().NotThrow();
+            action7.Should().Throw<ArgumentNullException>("userTypeService is null.");
         }
 
         /// <summary>
-        /// Success Test to Syncs group members to repository.
+        /// Test case to verify that new Member users is stored in Sent Notification Table.
         /// </summary>
         /// <returns>A task that represents the work queued to execute.</returns>
         [Fact]
-        public async Task SyncGroupMembersActivitySuccessTest()
+        public async Task SyncGroupMembers_OnlyMemberNewUserType_StoreInSentNotificationTable()
         {
             // Arrange
             var groupId = "Group1";
@@ -70,14 +74,20 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
             var activityContext = this.GetSyncGroupMembersActivity();
             var users = new List<User>()
             {
-                new User() { Id = "userId" },
+                new User() { Id = "userId", UserPrincipalName = "userPrincipalName" },
             };
+            UserDataEntity userDataEntity = null;
+
             this.groupMembersService
                 .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
                 .ReturnsAsync(users);
+
             this.userDataRepository
                 .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult(default(UserDataEntity)));
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
             this.sentNotificationDataRepository
                 .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
                 .Returns(Task.CompletedTask);
@@ -91,11 +101,248 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         }
 
         /// <summary>
-        /// ArgumentNullException Test.
+        /// Test case to verify that new Guest Users never gets saved in Sent Notification Table.
         /// </summary>
         /// <returns>A task that represents the work queued to execute.</returns>
         [Fact]
-        public async Task ArgumentNullExceptionTest()
+        public async Task SyncGroupMembers_OnlyGuestNewUsersType_NeverStoreInSentNotificationTable()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            var users = new List<User>()
+            {
+                new User() { Id = "userId", UserPrincipalName = "#ext#" },
+            };
+            UserDataEntity userDataEntity = null;
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that only Member user type is filtered from list of new Member user and Guest user,
+        /// and is saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_BothUserTypeForNewUser_StoreOnlyMemberUserType()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            var users = new List<User>()
+            {
+                new User() { Id = "userId1", UserPrincipalName = "userPrincipalName1" },
+                new User() { Id = "userId2", UserPrincipalName = "#ext#" },
+            };
+            UserDataEntity userDataEntity = null;
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 1)), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that existing Member users is stored in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_OnlyMemberExistingUserType_StoreInSentNotificationTable()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            var users = new List<User>()
+            {
+                new User() { Id = "userId", UserPrincipalName = "userPrincipalName" },
+            };
+            var userDataEntity = new UserDataEntity()
+            {
+                UserId = "userId",
+            };
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(x => x.FirstOrDefault().PartitionKey == notificationId)));
+        }
+
+        /// <summary>
+        /// Test case to verify that existing Guest Users never gets saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_OnlyGuestExistingUsersType_NeverStoreInSentNotificationTable()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            var users = new List<User>()
+            {
+                new User() { Id = "userId", UserPrincipalName = "#ext#" },
+            };
+            var userDataEntity = new UserDataEntity()
+            {
+                UserId = "userId",
+            };
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that only Member user type is filtered from list of existing Member user and Guest user,
+        /// and is saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_BothUserTypeForExistingUser_StoreOnlyMemberUserType()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            var users = new List<User>()
+            {
+                new User() { Id = "userId1", UserPrincipalName = "userPrincipalName1" },
+                new User() { Id = "userId2", UserPrincipalName = "#ext#" },
+            };
+            var userDataEntity = new UserDataEntity()
+            {
+                UserId = "userId1",
+            };
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntity);
+            this.userTypeService
+                .Setup(x => x.UpdateUserTypeForExistingUserAsync(It.IsAny<UserDataEntity>(), It.IsAny<string>()));
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 1)), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to check if exception is caught and logged in case graph returns null reponse.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_NullResponseFromGraph_CatchExceptionAndLog()
+        {
+            // Arrange
+            var groupId = "Group1";
+            var notificationId = "notificaionId";
+            var activityContext = this.GetSyncGroupMembersActivity();
+            List<User> users = null;
+            var userDataEntity = new UserDataEntity()
+            {
+                UserId = "userId",
+            };
+
+            this.groupMembersService
+                .Setup(x => x.GetGroupMembersAsync(It.IsAny<string>()))
+                .ReturnsAsync(users);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((notificationId, groupId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.notificationDataRepository.Verify(x => x.SaveWarningInNotificationDataEntityAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to check ArgumentNullException is thrown when parameter is null.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncGroupMembers_NullParameter_ShouldThrowException()
         {
             // Arrange
             var groupId = "GroupId";
@@ -118,7 +365,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         /// </summary>
         private SyncGroupMembersActivity GetSyncGroupMembersActivity()
         {
-            return new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.localier.Object);
+            return new SyncGroupMembersActivity(this.sentNotificationDataRepository.Object, this.notificationDataRepository.Object, this.groupMembersService.Object, this.userDataRepository.Object, this.userTypeService.Object, this.localier.Object);
         }
     }
 }

--- a/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncTeamMembersActivityTest.cs
+++ b/Source/Test/CompanyCommunicator.Prep.Func.Test/PreparingToSend/Activities/SyncTeamMembersActivityTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
     using Microsoft.Extensions.Localization;
@@ -16,7 +17,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.TeamData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Repositories.UserData;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Resources;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGraph;
     using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.Teams;
+    using Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.User;
     using Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.PreparingToSend;
     using Moq;
     using Xunit;
@@ -33,6 +36,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         private readonly Mock<ISentNotificationDataRepository> sentNotificationDataRepository = new Mock<ISentNotificationDataRepository>();
         private readonly Mock<INotificationDataRepository> notificationDataRepository = new Mock<INotificationDataRepository>();
         private readonly Mock<ITeamDataRepository> teamDataRepository = new Mock<ITeamDataRepository>();
+        private readonly Mock<IUserTypeService> userTypeService = new Mock<IUserTypeService>();
         private readonly string teamId = "121";
         private readonly string notificationId = "111";
 
@@ -43,13 +47,14 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         public void SyncTeamMembersActivityConstructorTest()
         {
             // Arrange
-            Action action1 = () => new SyncTeamMembersActivity(null /*teamDataRepository*/, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object);
-            Action action2 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, null /*membersService*/, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object);
-            Action action3 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, null /*notificationDataRepository*/, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object);
-            Action action4 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, null /*sentNotificationDataRepository*/, this.localier.Object, this.userDataRepository.Object);
-            Action action5 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, null /*localier*/, this.userDataRepository.Object);
-            Action action6 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, null /*userDataRepository*/);
-            Action action7 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object);
+            Action action1 = () => new SyncTeamMembersActivity(null /*teamDataRepository*/, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
+            Action action2 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, null /*membersService*/, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
+            Action action3 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, null /*notificationDataRepository*/, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
+            Action action4 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, null /*sentNotificationDataRepository*/, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
+            Action action5 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, null /*localier*/, this.userDataRepository.Object, this.userTypeService.Object);
+            Action action6 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, null /*userDataRepository*/, this.userTypeService.Object);
+            Action action7 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, null /*userTypeService*/);
+            Action action8 = () => new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
 
             // Act and Assert.
             action1.Should().Throw<ArgumentNullException>("teamDataRepository is null.");
@@ -57,41 +62,231 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
             action3.Should().Throw<ArgumentNullException>("notificationDataRepository is null.");
             action4.Should().Throw<ArgumentNullException>("sentNotificationDataRepository is null.");
             action5.Should().Throw<ArgumentNullException>("localier is null.");
-            action5.Should().Throw<ArgumentNullException>("userDataRepository is null.");
-            action7.Should().NotThrow();
+            action6.Should().Throw<ArgumentNullException>("userDataRepository is null.");
+            action6.Should().Throw<ArgumentNullException>("userTypeService is null.");
+            action8.Should().NotThrow();
         }
 
         /// <summary>
-        /// Success test for syncs team members to repository.
+        /// Test case to verify that existing Member users is stored in Sent Notification Table.
         /// </summary>
         /// <returns>A task that represents the work queued to execute.</returns>
         [Fact]
-        public async Task SyncTeamMembersActivitySuccessTest()
+        public async Task SyncTeamMembers_OnlyExistingMemberUser_StoreInSentNotificationTable()
         {
             // Arrange
             var activityContext = this.GetSyncTeamMembersActivity();
-            TeamDataEntity teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
-            IEnumerable<UserDataEntity> userData = new List<UserDataEntity>()
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
             {
-                new UserDataEntity(),
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Member },
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Member },
             };
+            var userData = new UserDataEntity() { UserId = "userId" };
             this.teamDataRepository
                 .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(teamData);
             this.membersService
                 .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(userData);
+
             this.sentNotificationDataRepository
                 .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
                 .Returns(Task.CompletedTask);
 
             // Act
-            Func<Task> task = async () => await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
 
             // Assert
-            await task.Should().NotThrowAsync();
-            this.teamDataRepository.Verify(x => x.GetAsync(It.IsAny<string>(), It.Is<string>(x => x.Equals(this.teamId))));
-            this.membersService.Verify(x => x.GetUsersAsync(It.Is<string>(x => x.Equals(teamData.TeamId)), It.Is<string>(x => x.Equals(teamData.TenantId)), It.Is<string>(x => x.Equals(teamData.ServiceUrl))));
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that existing Guest Users never gets saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_OnlyExistingGuestUser_NeverStoreInSentNotificationTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Guest },
+            };
+            var userData = new UserDataEntity() { UserId = "userId", UserType = UserType.Guest };
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that only Member user type is filtered from list of existing Member user and Guest user,
+        /// and is saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_BothUserTypeForExistingUser_StoreOnlyMemberUserType()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { UserId = "userId1", UserType = UserType.Guest },
+                new UserDataEntity() { UserId = "userId2", UserType = UserType.Member },
+            };
+            var userData = new UserDataEntity() { UserId = "userId1" };
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 1)), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that new Member users is stored in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_OnlyNewMemberUser_StoreInSentNotificationTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Member },
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Member },
+            };
+            UserDataEntity userData = null;
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Test case to verify that existing Guest Users never gets saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_OnlyNewGuestUser_NeverStoreInSentNotificationTable()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { UserId = "userId", UserType = UserType.Guest },
+            };
+            UserDataEntity userData = null;
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()), Times.Never);
+        }
+
+        /// <summary>
+        /// Test case to verify that only Member user type is filtered from list of new Member user and Guest user,
+        /// and is saved in Sent Notification Table.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_BothUserTypeForNewUser_StoreOnlyMemberUserType()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            var userDataList = new List<UserDataEntity>()
+            {
+                new UserDataEntity() { UserId = "userId1", UserType = UserType.Guest },
+                new UserDataEntity() { UserId = "userId2", UserType = UserType.Member },
+            };
+            UserDataEntity userData = null;
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataList);
+            this.userDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userData);
+
+            this.sentNotificationDataRepository
+                .Setup(x => x.BatchInsertOrMergeAsync(It.IsAny<IEnumerable<SentNotificationDataEntity>>()))
+                .Returns(Task.CompletedTask);
+
+            // Act
+            await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            this.sentNotificationDataRepository.Verify(x => x.BatchInsertOrMergeAsync(It.Is<IEnumerable<SentNotificationDataEntity>>(l => l.Count() == 1)), Times.Once);
         }
 
         /// <summary>
@@ -118,6 +313,32 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
             // Assert
             await task.Should().NotThrowAsync();
             this.notificationDataRepository.Verify(x => x.SaveWarningInNotificationDataEntityAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<string>()));
+        }
+
+        /// <summary>
+        /// Test case to check if exception is caught and logged in case graph returns null reponse.
+        /// </summary>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        [Fact]
+        public async Task SyncTeamMembers_NullResponseFromBotAPI_CatchExceptionAndLog()
+        {
+            // Arrange
+            var activityContext = this.GetSyncTeamMembersActivity();
+            var teamData = new TeamDataEntity() { TenantId = "Tanant1", TeamId = "Team1", ServiceUrl = "serviceUrl" };
+            IEnumerable<UserDataEntity> userDataEntities = null;
+            this.teamDataRepository
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(teamData);
+            this.membersService
+                .Setup(x => x.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(userDataEntities);
+
+            // Act
+            Func<Task> task = async () => await activityContext.RunAsync((this.notificationId, this.teamId), this.logger.Object);
+
+            // Assert
+            await task.Should().NotThrowAsync();
+            this.notificationDataRepository.Verify(x => x.SaveWarningInNotificationDataEntityAsync(It.Is<string>(x => x.Equals(this.notificationId)), It.IsAny<string>()), Times.Once);
         }
 
         /// <summary>
@@ -148,7 +369,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Prep.Func.Test.PreparingToSen
         /// </summary>
         private SyncTeamMembersActivity GetSyncTeamMembersActivity()
         {
-            return new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object);
+            return new SyncTeamMembersActivity(this.teamDataRepository.Object, this.membersService.Object, this.notificationDataRepository.Object, this.sentNotificationDataRepository.Object, this.localier.Object, this.userDataRepository.Object, this.userTypeService.Object);
         }
     }
 }


### PR DESCRIPTION
- Support identification of existing users as **Member or Guest** and store in the storage account.
 ref : https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0 
  The user type is set when below options are used:
  - Send 1-1 chat message in a team.
  - Send 1-1 message to M365 group, DL and security group.
  - Send to All Users.
  - Export Report.
- New/Existing guest user will be skipped while sending messages.
- **UserType** column is added to export report, to view the type of user who received the message. 
- Added unit test cases.