### PR TITLE
Add Tls12, softDelete and azurebot into ARM templates 

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -311,7 +311,8 @@
       "kind": "Storage",
       "properties": {
         "supportsHttpsTrafficOnly": true,
-        "allowBlobPublicAccess": false
+        "allowBlobPublicAccess": false,
+        "minimumTlsVersion": "TLS1_2"
       },
       "sku": {
         "name": "Standard_LRS"
@@ -449,14 +450,14 @@
       }
     },
     {
-      "apiVersion": "2018-07-12",
+      "apiVersion": "2021-03-01",
       "name": "[variables('authorBotName')]",
       "type": "Microsoft.BotService/botServices",
       "location": "global",
       "sku": {
         "name": "F0"
       },
-      "kind": "sdk",
+      "kind": "azurebot",
       "properties": {
         "displayName": "[concat(parameters('appDisplayName'),'-author')]",
         "description": "[parameters('appDescription')]",
@@ -488,14 +489,14 @@
       ]
     },
     {
-      "apiVersion": "2018-07-12",
+      "apiVersion": "2021-03-01",
       "name": "[variables('botName')]",
       "type": "Microsoft.BotService/botServices",
       "location": "global",
       "sku": {
         "name": "F0"
       },
-      "kind": "sdk",
+      "kind": "azurebot",
       "properties": {
         "displayName": "[parameters('appDisplayName')]",
         "description": "[parameters('appDescription')]",
@@ -508,7 +509,7 @@
         {
           "name": "[concat(variables('botName'), '/MsTeamsChannel')]",
           "type": "Microsoft.BotService/botServices/channels",
-          "apiVersion": "2018-07-12",
+          "apiVersion": "2021-03-01",
           "location": "global",
           "sku": {
             "name": "F0"
@@ -893,6 +894,7 @@
       },
       "properties": {
         "tenantId": "[variables('subscriptionTenantId')]",
+        "enableSoftDelete": true,
         "enabledForDeployment": false,
         "enabledForDiskEncryption": false,
         "enabledForTemplateDeployment": true,

--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -470,7 +470,7 @@
         {
           "name": "[concat(variables('authorBotName'), '/MsTeamsChannel')]",
           "type": "Microsoft.BotService/botServices/channels",
-          "apiVersion": "2018-07-12",
+          "apiVersion": "2021-03-01",
           "location": "global",
           "sku": {
             "name": "F0"

--- a/Deployment/azuredeploywithcert.json
+++ b/Deployment/azuredeploywithcert.json
@@ -311,7 +311,8 @@
       "kind": "Storage",
       "properties": {
         "supportsHttpsTrafficOnly": true,
-        "allowBlobPublicAccess": false
+        "allowBlobPublicAccess": false,
+        "minimumTlsVersion": "TLS1_2"
       },
       "sku": {
         "name": "Standard_LRS"
@@ -449,14 +450,14 @@
       }
     },
     {
-      "apiVersion": "2018-07-12",
+      "apiVersion": "2021-03-01",
       "name": "[variables('authorBotName')]",
       "type": "Microsoft.BotService/botServices",
       "location": "global",
       "sku": {
         "name": "F0"
       },
-      "kind": "sdk",
+      "kind": "azurebot",
       "properties": {
         "displayName": "[concat(parameters('appDisplayName'),'-author')]",
         "description": "[parameters('appDescription')]",
@@ -469,7 +470,7 @@
         {
           "name": "[concat(variables('authorBotName'), '/MsTeamsChannel')]",
           "type": "Microsoft.BotService/botServices/channels",
-          "apiVersion": "2018-07-12",
+          "apiVersion": "2021-03-01",
           "location": "global",
           "sku": {
             "name": "F0"
@@ -488,14 +489,14 @@
       ]
     },
     {
-      "apiVersion": "2018-07-12",
+      "apiVersion": "2021-03-01",
       "name": "[variables('botName')]",
       "type": "Microsoft.BotService/botServices",
       "location": "global",
       "sku": {
         "name": "F0"
       },
-      "kind": "sdk",
+      "kind": "azurebot",
       "properties": {
         "displayName": "[parameters('appDisplayName')]",
         "description": "[parameters('appDescription')]",
@@ -508,7 +509,7 @@
         {
           "name": "[concat(variables('botName'), '/MsTeamsChannel')]",
           "type": "Microsoft.BotService/botServices/channels",
-          "apiVersion": "2018-07-12",
+          "apiVersion": "2021-03-01",
           "location": "global",
           "sku": {
             "name": "F0"
@@ -904,6 +905,7 @@
       ],
       "properties": {
         "tenantId": "[variables('subscriptionTenantId')]",
+        "enableSoftDelete": true,
         "accessPolicies": [
           {
             "tenantId": "[reference(concat('Microsoft.Web/sites/', variables('botAppName')), '2018-02-01', 'Full').identity.tenantId]",

--- a/Source/CompanyCommunicator/Microsoft.Teams.Apps.CompanyCommunicator.csproj
+++ b/Source/CompanyCommunicator/Microsoft.Teams.Apps.CompanyCommunicator.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.16" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.12.1" />


### PR DESCRIPTION
For both ARM templates add the following settings:

- Set a minimum required version of TLS to 1.2 for a storage account.
- Set kind equals "azurebot" for Azure Bot.
- Set enable soft delete for Key Vault.

#544 