### PR TITLE
Rename default branch from master to main in ARM templates

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -136,7 +136,7 @@
     "appIconUrl": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-company-communicator-app/master/Manifest/color.png",
+      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-company-communicator-app/main/Manifest/color.png",
       "metadata": {
         "description": "The link to the icon for the app. It must resolve to a PNG file."
       }
@@ -193,7 +193,7 @@
       "metadata": {
         "description": "The branch of the GitHub repository to deploy."
       },
-      "defaultValue": "master"
+      "defaultValue": "main"
     },
     "serviceBusWebAppRoleNameGuid": {
       "defaultValue": "958380b3-630d-4823-b933-f59d92cdcada",

--- a/Deployment/azuredeploywithcert.json
+++ b/Deployment/azuredeploywithcert.json
@@ -142,7 +142,7 @@
     "appIconUrl": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-company-communicator-app/master/Manifest/color.png",
+      "defaultValue": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-company-communicator-app/main/Manifest/color.png",
       "metadata": {
         "description": "The link to the icon for the app. It must resolve to a PNG file."
       }
@@ -199,7 +199,7 @@
       "metadata": {
         "description": "The branch of the GitHub repository to deploy."
       },
-      "defaultValue": "master"
+      "defaultValue": "main"
     },
     "serviceBusWebAppRoleNameGuid": {
       "defaultValue": "958380b3-630d-4823-b933-f59d92cdcada",


### PR DESCRIPTION
Since the default branch in the repo was changed, we have to rename any "master" in ARM templates to "main".