### PR TITLE
Fix deploy script errors which failed on latest az and AzureAD tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,7 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+parameters.local.json
+
+*.zip

--- a/Deployment/deploy.ps1
+++ b/Deployment/deploy.ps1
@@ -306,7 +306,7 @@ function CreateAzureADApp {
             if ($updateDecision -eq 0) {
                 WriteI -message "Updating the existing app..."
 
-                az ad app update --id $app.appId --available-to-other-tenants $MultiTenant --oauth2-allow-implicit-flow $AllowImplicitFlow
+                az ad app update --id $app.appId --sign-in-audience AzureADMultipleOrgs --enable-access-token-issuance $AllowImplicitFlow
 
                 WriteI -message "Waiting for app update to finish..."
 
@@ -319,11 +319,11 @@ function CreateAzureADApp {
             }
         } else {
             # Create Azure AD app registration using CLI
-             az ad app create --display-name $appName --available-to-other-tenants $MultiTenant --oauth2-allow-implicit-flow $AllowImplicitFlow
+             az ad app create --display-name $appName --sign-in-audience AzureADMultipleOrgs --enable-access-token-issuance $AllowImplicitFlow
 
             WriteI -message "Waiting for app creation to finish..."
 
-            Start-Sleep -s 10
+            Start-Sleep -s 30
 
             WriteS -message "Azure AD App: $appName is created."
         }
@@ -772,7 +772,7 @@ function ADAppUpdate {
     az ad app update --id $configAppId --identifier-uris $IdentifierUris
     WriteI -message "App URI set"        
             
-    $configApp = az ad app update --id $configAppId --reply-urls $RedirectUris
+    $configApp = az ad app update --id $configAppId --web-redirect-uris $RedirectUris
     WriteI -message "App reply-urls set"  
             
     az ad app update --id $configAppId --optional-claims './AadOptionalClaims.json'
@@ -996,7 +996,7 @@ function logout {
 
                 if (-not (Get-Module -ListAvailable -Name "AzureAD")) {
                     WriteI -message"Installing AzureAD module..."
-                    Install-Module AzureAD -Scope CurrentUser -Force
+                    Install-Module AzureAD -AllowClobber -Scope CurrentUser -Force
                 }
                 
                 if (-not (Get-Module -ListAvailable -Name "WriteAscii")) {
@@ -1023,7 +1023,7 @@ function logout {
     }
 
 # Start Deployment.
-    Write-Ascii -InputObject "Company Communicator v5.2" -ForegroundColor Magenta
+    Write-Ascii -InputObject "Company Communicator v5.4" -ForegroundColor Magenta
     WriteI -message "Starting deployment..."
 
 # Initialize connections - Azure Az/CLI/Azure AD


### PR DESCRIPTION
The script was not updated per this guide:
https://learn.microsoft.com/en-us/cli/azure/microsoft-graph-migration#az-ad-app-createupdate

And hit below issues:

![image](https://github.com/OfficeDev/microsoft-teams-apps-company-communicator/assets/8623897/6a2024f7-6b3b-44f1-bdfa-d0c4ea66d47c)

<img width="533" alt="image" src="https://github.com/OfficeDev/microsoft-teams-apps-company-communicator/assets/8623897/36796470-4ada-4547-96de-15d891a53aee">
